### PR TITLE
Set up Cloud dev environment for Bagrry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Bagrry is a single product: a **Tauri v2 + React 19 desktop app** living in `desktop/`. There is no separate backend server — the Rust side (`desktop/src-tauri`) hosts an embedded SQLite DB, audio capture, tray, and global hotkeys, and the React frontend talks to it over Tauri IPC. Standard scripts live in `desktop/package.json`; run everything from `desktop/`.
+
+### Running / building / linting
+
+- Package manager is **Bun** (`bun.lock`). JS deps are refreshed by the startup update script (`bun install --cwd desktop`).
+- Run the full app in dev: `bun run tauri dev` (starts Vite on `http://localhost:1420`, then compiles and launches the native window). The first Rust build takes ~1 min; subsequent runs are incremental.
+- Frontend typecheck + build (doubles as the lint/typecheck gate): `bun run build` (runs `tsc && vite build`).
+- Rust check/build: `cd src-tauri && cargo check` (or `cargo build`). There is no separate JS linter (no ESLint config).
+
+### Non-obvious gotchas
+
+- **GUI needs an X display.** This is a desktop GUI app; there is a real X server on `DISPLAY=:1`. Always `export DISPLAY=:1` before `bun run tauri dev` or the window won't appear.
+- **Rust toolchain must be modern.** Transitive deps require edition2024, so use Rust **stable ≥ 1.85** (the VM is pinned to current stable via `rustup default stable`). The old 1.83 toolchain fails to resolve `toml_datetime`.
+- `libEGL warning: DRI3 error ...` on launch is harmless — it just falls back to software rendering in the VM.
+- **Audio/system-audio is platform-limited.** WASAPI system-audio loopback is Windows-only (`#[cfg(not(windows))]` stubs it out). On this Linux VM `cpal` mic capture may find no input device, so recording/VU features can't be fully exercised here; use SQLite-backed flows (create/list meetings, templates, folders) to verify the IPC stack end-to-end.
+- SQLite lives at `{app_data_dir}/bagrry.sqlite` inside the Tauri app data dir; schema + seed data (default folder, templates, recipes) are applied automatically on first launch by `db::open`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Sets up the Cursor Cloud development environment for **Bagrry** (Tauri v2 + React 19 desktop meeting-notes app) and documents durable, non-obvious setup notes for future agents.

## Changes

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering how to run/build/lint the app, plus non-obvious gotchas (X display requirement, Rust toolchain version, platform-limited audio, harmless libEGL warning).

## Environment setup performed (not code changes)

- Installed Tauri Linux system deps (`libwebkit2gtk-4.1-dev`, GTK, `libayatana-appindicator3-dev`, `librsvg2-dev`, `libasound2-dev`, build tooling).
- Installed **Bun** and JS deps (`bun install`).
- Upgraded Rust toolchain to current stable (1.83 → 1.97) — required because transitive deps need edition2024.
- Update script registered: `bun install --cwd desktop`.

## Verification

| Service | Command | Result |
| --- | --- | --- |
| Frontend typecheck + build | `bun run build` (`tsc && vite build`) | Pass — 1870 modules, built in ~1.2s |
| Rust backend | `cargo check` | Pass — finished in ~47s |
| Full desktop app (dev) | `bun run tauri dev` (`DISPLAY=:1`) | Launches native window, renders UI |

**Hello-world task:** Created meetings from the UI. The sidebar counter went `SQLite 3.46.0 · 0 meetings` → `1 meetings` → `2 meetings`, and entries appeared in the list — verifying the full React UI → Tauri IPC → Rust command → SQLite insert → query refresh pipeline.

[bagrry_create_meeting_demo.mp4](https://cursor.com/agents/bc-ee92150e-132f-4943-a37d-9b6071bdf022/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbagrry_create_meeting_demo.mp4)

[Bagrry with 0 meetings](https://cursor.com/agents/bc-ee92150e-132f-4943-a37d-9b6071bdf022/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbagrry_0_meetings.webp)
[Bagrry with 2 meetings](https://cursor.com/agents/bc-ee92150e-132f-4943-a37d-9b6071bdf022/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbagrry_2_meetings.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee92150e-132f-4943-a37d-9b6071bdf022?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee92150e-132f-4943-a37d-9b6071bdf022&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

