### PR TITLE
Workspace, templates, command palette, and note operations

### DIFF
--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -871,3 +871,166 @@ pub fn save_custom_template(
     .map_err(|e| e.to_string())?;
     Ok(())
 }
+
+#[derive(Serialize)]
+pub struct Attachment {
+    pub id: String,
+    pub meeting_id: String,
+    pub filename: String,
+    pub extracted_text: Option<String>,
+}
+
+#[tauri::command]
+pub fn delete_meeting(state: State<AppState>, id: String) -> Result<(), String> {
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+    conn.execute("DELETE FROM meetings WHERE id=?1", params![id])
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn move_meeting(
+    state: State<AppState>,
+    id: String,
+    folder_id: Option<String>,
+) -> Result<(), String> {
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+    conn.execute(
+        "UPDATE meetings SET folder_id=?1, updated_at=datetime('now') WHERE id=?2",
+        params![folder_id, id],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn set_folder_shared(
+    state: State<AppState>,
+    id: String,
+    is_shared: bool,
+) -> Result<(), String> {
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+    conn.execute(
+        "UPDATE folders SET is_shared=?1 WHERE id=?2",
+        params![if is_shared { 1 } else { 0 }, id],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn list_meeting_attendees(
+    state: State<AppState>,
+    meeting_id: String,
+) -> Result<Vec<Person>, String> {
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT a.id, a.name, a.email, a.domain, a.company_id
+             FROM attendees a
+             JOIN meeting_attendees ma ON ma.attendee_id = a.id
+             WHERE ma.meeting_id=?1
+             ORDER BY a.name",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map(params![meeting_id], |row| {
+            Ok(Person {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                email: row.get(2)?,
+                domain: row.get(3)?,
+                company_id: row.get(4)?,
+            })
+        })
+        .map_err(|e| e.to_string())?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn add_meeting_attendee(
+    state: State<AppState>,
+    meeting_id: String,
+    person_id: String,
+) -> Result<(), String> {
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+    conn.execute(
+        "INSERT OR IGNORE INTO meeting_attendees (meeting_id, attendee_id) VALUES (?1,?2)",
+        params![meeting_id, person_id],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn list_attachments(
+    state: State<AppState>,
+    meeting_id: String,
+) -> Result<Vec<Attachment>, String> {
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, meeting_id, filename, extracted_text FROM attachments WHERE meeting_id=?1 ORDER BY filename",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map(params![meeting_id], |row| {
+            Ok(Attachment {
+                id: row.get(0)?,
+                meeting_id: row.get(1)?,
+                filename: row.get(2)?,
+                extracted_text: row.get(3)?,
+            })
+        })
+        .map_err(|e| e.to_string())?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn save_custom_recipe(
+    state: State<AppState>,
+    name: String,
+    prompt_template: String,
+) -> Result<(), String> {
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+    conn.execute(
+        "INSERT INTO recipes (id, name, prompt_template, icon) VALUES (?1,?2,?3,'sparkles')",
+        params![new_id("rcp"), name, prompt_template],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn add_action_item(
+    state: State<AppState>,
+    meeting_id: String,
+    task: String,
+    owner: Option<String>,
+    deadline: Option<String>,
+) -> Result<ActionItem, String> {
+    let conn = state.db.lock().map_err(|e| e.to_string())?;
+    let id = new_id("act");
+    conn.execute(
+        "INSERT INTO action_items (id, meeting_id, owner, task, deadline) VALUES (?1,?2,?3,?4,?5)",
+        params![id, meeting_id, owner, task, deadline],
+    )
+    .map_err(|e| e.to_string())?;
+    let meeting_title: String = conn
+        .query_row(
+            "SELECT title FROM meetings WHERE id=?1",
+            params![meeting_id],
+            |row| row.get(0),
+        )
+        .unwrap_or_else(|_| "Meeting".into());
+    Ok(ActionItem {
+        id,
+        meeting_id,
+        meeting_title,
+        owner,
+        task,
+        deadline,
+    })
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -81,6 +81,14 @@ pub fn run() {
             commands::save_attachment_text,
             commands::create_folder,
             commands::save_custom_template,
+            commands::delete_meeting,
+            commands::move_meeting,
+            commands::set_folder_shared,
+            commands::list_meeting_attendees,
+            commands::add_meeting_attendee,
+            commands::list_attachments,
+            commands::save_custom_recipe,
+            commands::add_action_item,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -4,6 +4,8 @@ import { AppShell } from "@/components/AppShell";
 import { Dashboard } from "@/components/Dashboard";
 import { LandingPage } from "@/components/LandingPage";
 import { NotesWorkspace } from "@/components/NotesWorkspace";
+import { CommandPalette } from "@/components/CommandPalette";
+import { Onboarding } from "@/components/Onboarding";
 import {
   ActionsPage,
   CalendarPage,
@@ -13,6 +15,8 @@ import {
   PricingPage,
   SearchPage,
   SettingsPage,
+  TemplatesPage,
+  WorkspacePage,
 } from "@/components/pages";
 import * as api from "@/lib/api";
 import type { RecStatus, VuLevels } from "@/lib/types";
@@ -45,6 +49,7 @@ export default function App() {
     return (
       <div className="h-full bg-[#f7f7f2] text-foreground">
         {overlayOn && recState === "recording" && <RecBadge />}
+        <CommandPalette />
         <LandingPage />
       </div>
     );
@@ -53,6 +58,8 @@ export default function App() {
   return (
     <div className="flex h-full min-h-0 w-full min-w-0 overflow-hidden bg-background text-foreground">
       {overlayOn && recState === "recording" && <RecBadge />}
+      <CommandPalette />
+      <Onboarding />
       <AppShell>
         {page === "dashboard" && <Dashboard />}
         {page === "notes" && (
@@ -65,6 +72,8 @@ export default function App() {
         {page === "companies" && <CompaniesPage />}
         {page === "calendar" && <CalendarPage />}
         {page === "actions" && <ActionsPage />}
+        {page === "templates" && <TemplatesPage />}
+        {page === "workspace" && <WorkspacePage />}
         {page === "pricing" && <PricingPage />}
         {page === "integrations" && <IntegrationsPage />}
         {page === "settings" && <SettingsPage />}

--- a/desktop/src/components/AppShell.tsx
+++ b/desktop/src/components/AppShell.tsx
@@ -5,10 +5,12 @@ import {
   CheckSquare,
   CreditCard,
   LayoutDashboard,
+  LayoutTemplate,
   Link2,
   MessageSquare,
   NotebookPen,
   Settings,
+  Shield,
   Users,
 } from "lucide-react";
 import type { Page } from "@/lib/types";
@@ -23,6 +25,7 @@ const ITEMS: { page: Page; label: string; icon: ReactNode }[] = [
   { page: "actions", label: "Actions", icon: <CheckSquare className="h-4 w-4" /> },
   { page: "people", label: "People", icon: <Users className="h-4 w-4" /> },
   { page: "companies", label: "Companies", icon: <Building2 className="h-4 w-4" /> },
+  { page: "templates", label: "Templates", icon: <LayoutTemplate className="h-4 w-4" /> },
 ];
 
 export function AppShell({ children }: { children: ReactNode }) {
@@ -52,6 +55,7 @@ export function AppShell({ children }: { children: ReactNode }) {
         ))}
         <div className="flex-1" />
         {recState === "recording" && <span className="mb-2 h-2 w-2 rounded-full bg-destructive" title="Recording" />}
+        <NavTiny page="workspace" current={page} onClick={setPage} icon={<Shield className="h-4 w-4" />} label="Workspace" />
         <NavTiny page="pricing" current={page} onClick={setPage} icon={<CreditCard className="h-4 w-4" />} label="Pricing" />
         <NavTiny page="integrations" current={page} onClick={setPage} icon={<Link2 className="h-4 w-4" />} label="Integrations" />
         <NavTiny page="settings" current={page} onClick={setPage} icon={<Settings className="h-4 w-4" />} label="Settings" />

--- a/desktop/src/components/CommandPalette.tsx
+++ b/desktop/src/components/CommandPalette.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import * as api from "@/lib/api";
+import type { Page } from "@/lib/types";
+import { useAppStore } from "@/store/app";
+import { cn } from "@/lib/utils";
+
+const GO: { page: Page; label: string; hint: string }[] = [
+  { page: "dashboard", label: "Go to Home", hint: "Dashboard" },
+  { page: "notes", label: "Go to Notes", hint: "Notepad" },
+  { page: "search", label: "Ask across meetings", hint: "Chat" },
+  { page: "calendar", label: "Calendar & briefs", hint: "Prep" },
+  { page: "actions", label: "Action items", hint: "Follow-up" },
+  { page: "people", label: "People", hint: "Directory" },
+  { page: "companies", label: "Companies", hint: "Accounts" },
+  { page: "templates", label: "Templates & recipes", hint: "Enhance" },
+  { page: "workspace", label: "Workspace", hint: "Plan & privacy" },
+  { page: "pricing", label: "Pricing", hint: "Plans" },
+  { page: "integrations", label: "Integrations", hint: "MCP & CRM" },
+  { page: "settings", label: "Settings", hint: "Keys" },
+  { page: "landing", label: "Marketing site", hint: "Landing" },
+];
+
+export function CommandPalette() {
+  const open = useAppStore((s) => s.paletteOpen);
+  const setOpen = useAppStore((s) => s.setPaletteOpen);
+  const setPage = useAppStore((s) => s.setPage);
+  const selectMeeting = useAppStore((s) => s.selectMeeting);
+  const setChatOpen = useAppStore((s) => s.setChatOpen);
+  const [q, setQ] = useState("");
+  const meetings = useQuery({
+    queryKey: ["meetings", null],
+    queryFn: () => api.listMeetings(null),
+    enabled: open,
+  });
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen(!useAppStore.getState().paletteOpen);
+      }
+      if (e.key === "Escape") setOpen(false);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [setOpen]);
+
+  const items = useMemo(() => {
+    const query = q.trim().toLowerCase();
+    const jumps = GO.filter((g) => !query || g.label.toLowerCase().includes(query) || g.hint.toLowerCase().includes(query));
+    const notes = (meetings.data ?? []).filter((m) => !query || m.title.toLowerCase().includes(query)).slice(0, 8);
+    return { jumps, notes };
+  }, [q, meetings.data]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[80] flex items-start justify-center bg-[#1c1914]/25 px-4 pt-[12vh] backdrop-blur-[2px]" onClick={() => setOpen(false)}>
+      <div
+        className="paper-card w-full max-w-xl overflow-hidden rounded-2xl border border-[#e4dfd3]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <input
+          autoFocus
+          className="h-12 w-full border-b border-border bg-transparent px-4 text-sm outline-none"
+          placeholder="Jump, search notes, or ask…"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+        />
+        <div className="max-h-80 overflow-y-auto p-2">
+          {items.jumps.map((g) => (
+            <button
+              key={g.page}
+              type="button"
+              className="flex w-full items-center justify-between rounded-xl px-3 py-2 text-left text-sm hover:bg-accent"
+              onClick={() => {
+                setPage(g.page);
+                setOpen(false);
+              }}
+            >
+              <span>{g.label}</span>
+              <span className="text-[11px] text-muted-foreground">{g.hint}</span>
+            </button>
+          ))}
+          {items.notes.length > 0 && (
+            <p className="px-3 pb-1 pt-3 text-[10px] uppercase tracking-[0.16em] text-muted-foreground">Notes</p>
+          )}
+          {items.notes.map((m) => (
+            <button
+              key={m.id}
+              type="button"
+              className="flex w-full rounded-xl px-3 py-2 text-left text-sm hover:bg-accent"
+              onClick={() => {
+                selectMeeting(m.id);
+                setOpen(false);
+              }}
+            >
+              {m.title}
+            </button>
+          ))}
+          {q.trim() && (
+            <button
+              type="button"
+              className={cn("mt-1 flex w-full rounded-xl px-3 py-2 text-left text-sm hover:bg-accent")}
+              onClick={() => {
+                setPage("search");
+                setChatOpen(true);
+                setOpen(false);
+              }}
+            >
+              Ask “{q.trim()}” across meetings
+            </button>
+          )}
+        </div>
+        <p className="border-t border-border px-4 py-2 text-[11px] text-muted-foreground">Ctrl+K · Esc to close</p>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/LandingPage.tsx
+++ b/desktop/src/components/LandingPage.tsx
@@ -167,6 +167,23 @@ export function LandingPage() {
           Open your dashboard
         </Button>
       </section>
+
+      <section className="relative mx-auto max-w-3xl px-6 pb-24">
+        <h2 className="font-display text-center text-3xl">Things worth noting</h2>
+        <div className="mt-8 space-y-3">
+          {[
+            ["Do you train models on my meetings?", "No. Audio never leaves RAM after transcription. Chat and enhance use your Groq key. Opt out of any provider training in Workspace."],
+            ["How do others know I’m taking notes?", "Copy a one-line consent message into Meet or Teams chat. Optional recording watermark sits at the top of the window."],
+            ["What’s on Basic vs Business?", "Basic is free with 30-day history in the app. Business is $14/user/mo for unlimited history, CRM connectors, and advanced chat."],
+            ["Where does data live?", "SQLite on this machine. Share links are local. MCP and the REST API bind to 127.0.0.1."],
+          ].map(([q, a]) => (
+            <details key={q} className="rounded-2xl border border-[#e4dfd3] bg-white/50 px-5 py-4">
+              <summary className="cursor-pointer font-medium">{q}</summary>
+              <p className="mt-2 text-sm leading-relaxed text-[#5c574f]">{a}</p>
+            </details>
+          ))}
+        </div>
+      </section>
     </div>
   );
 }

--- a/desktop/src/components/NotesWorkspace.tsx
+++ b/desktop/src/components/NotesWorkspace.tsx
@@ -44,6 +44,17 @@ export function NotesWorkspace() {
     queryFn: () => api.listSegments(selectedMeetingId!),
     enabled: !!selectedMeetingId,
   });
+  const people = useQuery({ queryKey: ["people"], queryFn: api.listPeople });
+  const attendees = useQuery({
+    queryKey: ["attendees", selectedMeetingId],
+    queryFn: () => api.listMeetingAttendees(selectedMeetingId!),
+    enabled: !!selectedMeetingId,
+  });
+  const attachments = useQuery({
+    queryKey: ["attachments", selectedMeetingId],
+    queryFn: () => api.listAttachments(selectedMeetingId!),
+    enabled: !!selectedMeetingId,
+  });
 
   const create = useMutation({
     mutationFn: () => api.createMeeting("Untitled meeting", folderId),
@@ -59,6 +70,7 @@ export function NotesWorkspace() {
   const [busy, setBusy] = useState<string | null>(null);
   const [scratch, setScratch] = useState("");
   const [folderName, setFolderName] = useState("");
+  const [pane, setPane] = useState<"enhanced" | "transcript">("enhanced");
   const saveTimer = useRef<number | null>(null);
   const wasLive = useRef(false);
   const finishing = useRef(false);
@@ -150,6 +162,7 @@ export function NotesWorkspace() {
             New note
           </Button>
         </div>
+        <p className="px-4 pb-2 text-[10px] text-muted-foreground">Ctrl+K command palette</p>
         <div className="px-3 pb-2">
           <select
             className="w-full rounded-xl border border-input bg-background px-2 py-1.5 text-xs"
@@ -160,9 +173,24 @@ export function NotesWorkspace() {
             {folders.data?.map((f) => (
               <option key={f.id} value={f.id}>
                 {f.name}
+                {f.is_shared ? " · shared" : ""}
               </option>
             ))}
           </select>
+          {folderId && (
+            <button
+              type="button"
+              className="mt-1 text-[11px] text-primary"
+              onClick={async () => {
+                const f = folders.data?.find((x) => x.id === folderId);
+                if (!f) return;
+                await api.setFolderShared(folderId, !f.is_shared);
+                queryClient.invalidateQueries({ queryKey: ["folders"] });
+              }}
+            >
+              {folders.data?.find((x) => x.id === folderId)?.is_shared ? "Make private" : "Share folder with team"}
+            </button>
+          )}
           <div className="mt-2 flex gap-1">
             <input
               className="h-8 flex-1 rounded-lg border border-input bg-background px-2 text-xs"
@@ -231,6 +259,61 @@ export function NotesWorkspace() {
               {pendingBytes > 0 ? ` · ${(pendingBytes / 1024).toFixed(0)} KB in RAM` : ""}
             </p>
             {busy && <p className="mt-1 max-w-xl text-xs font-medium text-destructive">{busy}</p>}
+            {selected && (
+              <div className="mt-2 flex min-w-0 flex-wrap items-center gap-1">
+                {attendees.data?.map((p) => (
+                  <span key={p.id} className="rounded-full bg-accent px-2 py-0.5 text-[11px]">
+                    {p.name}
+                  </span>
+                ))}
+                <select
+                  className="h-7 rounded-full border border-input bg-background px-2 text-[11px]"
+                  defaultValue=""
+                  onChange={async (e) => {
+                    const pid = e.target.value;
+                    e.target.value = "";
+                    if (!pid) return;
+                    await api.addMeetingAttendee(selected.id, pid);
+                    queryClient.invalidateQueries({ queryKey: ["attendees", selected.id] });
+                  }}
+                >
+                  <option value="">Add attendee</option>
+                  {people.data?.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  className="h-7 rounded-full border border-input bg-background px-2 text-[11px]"
+                  value={selected.folder_id ?? ""}
+                  onChange={async (e) => {
+                    await api.moveMeeting(selected.id, e.target.value || null);
+                    queryClient.invalidateQueries({ queryKey: ["meeting", selected.id] });
+                    queryClient.invalidateQueries({ queryKey: ["meetings"] });
+                  }}
+                >
+                  <option value="">Inbox</option>
+                  {folders.data?.map((f) => (
+                    <option key={f.id} value={f.id}>
+                      {f.name}
+                    </option>
+                  ))}
+                </select>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="rounded-full text-destructive"
+                  onClick={async () => {
+                    await api.deleteMeeting(selected.id);
+                    selectMeeting(null);
+                    queryClient.invalidateQueries({ queryKey: ["meetings"] });
+                  }}
+                >
+                  Delete
+                </Button>
+              </div>
+            )}
           </div>
           <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
             <VuMeter mic={vu.mic} system={vu.system} />
@@ -341,37 +424,73 @@ export function NotesWorkspace() {
           )}
         </div>
         <section className="grid min-h-0 min-w-0 flex-1 grid-cols-2 overflow-hidden [grid-template-columns:minmax(0,1fr)_minmax(0,1fr)]">
-          <div className="flex min-h-0 min-w-0 flex-col overflow-hidden border-r border-border p-6">
+          <div
+            className="flex min-h-0 min-w-0 flex-col overflow-hidden border-r border-border p-6"
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={async (e) => {
+              e.preventDefault();
+              if (!selectedMeetingId) return;
+              const file = e.dataTransfer.files[0];
+              if (!file) return;
+              try {
+                const text = await file.text();
+                await api.saveAttachmentText(selectedMeetingId, file.name, text.slice(0, 20000));
+                queryClient.invalidateQueries({ queryKey: ["attachments", selectedMeetingId] });
+                setBusy(`Attached ${file.name}`);
+              } catch (err) {
+                setBusy(String(err));
+              }
+            }}
+          >
             <p className="mb-3 text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
               My notes
             </p>
             <NoteEditor value={scratch} onChange={onScratch} placeholder="Keywords, decisions, numbers…" />
+            {(attachments.data?.length ?? 0) > 0 && (
+              <p className="mt-2 text-[11px] text-muted-foreground">
+                Context: {attachments.data?.map((a) => a.filename).join(", ")}
+              </p>
+            )}
+            <p className="mt-1 text-[10px] text-muted-foreground">Drop a .txt, .md, or .csv for extra context.</p>
             <RepromptBar meetingId={selectedMeetingId} scratch={scratch} />
           </div>
-          <div className="min-h-0 min-w-0 overflow-hidden bg-[#fbfaf5] p-6">
-            <p className="mb-3 text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-              Enhanced
-            </p>
-            <EnhancedNotes json={selected?.enhanced_notes_json ?? null} segments={segments.data ?? []} />
-            {(segments.data?.length ?? 0) > 0 && (
-              <div className="mt-6 border-t border-border pt-4">
-                <p className="mb-2 text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-                  Transcript
-                </p>
-                <div className="max-h-48 space-y-2 overflow-y-auto text-xs">
-                  {segments.data?.map((s) => (
-                    <p key={s.id} className="leading-relaxed">
-                      <span className="font-medium text-muted-foreground">{s.speaker}</span>{" "}
-                      <span className={s.speaker === "me" ? "" : "ai-text"}>{s.text}</span>
-                    </p>
-                  ))}
-                </div>
+          <div className="flex min-h-0 min-w-0 flex-col overflow-hidden bg-[#fbfaf5] p-6">
+            <div className="mb-3 flex gap-2">
+              {(["enhanced", "transcript"] as const).map((id) => (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setPane(id)}
+                  className={cn(
+                    "rounded-full px-3 py-1 text-[10px] font-medium uppercase tracking-[0.16em]",
+                    pane === id ? "bg-accent text-primary" : "text-muted-foreground",
+                  )}
+                >
+                  {id}
+                </button>
+              ))}
+            </div>
+            {pane === "enhanced" ? (
+              <div className="min-h-0 flex-1 overflow-auto">
+                <EnhancedNotes json={selected?.enhanced_notes_json ?? null} segments={segments.data ?? []} />
+                {recipeOut && (
+                  <pre className="mt-4 max-h-48 overflow-auto whitespace-pre-wrap rounded-xl bg-muted/70 p-3 text-xs">
+                    {recipeOut}
+                  </pre>
+                )}
               </div>
-            )}
-            {recipeOut && (
-              <pre className="mt-4 max-h-48 overflow-auto whitespace-pre-wrap rounded-xl bg-muted/70 p-3 text-xs">
-                {recipeOut}
-              </pre>
+            ) : (
+              <div className="min-h-0 flex-1 space-y-2 overflow-auto text-xs">
+                {(segments.data?.length ?? 0) === 0 && (
+                  <p className="text-sm text-muted-foreground">Transcript appears after you stop recording.</p>
+                )}
+                {segments.data?.map((s) => (
+                  <p key={s.id} className="leading-relaxed">
+                    <span className="font-medium text-muted-foreground">{s.speaker}</span>{" "}
+                    <span className={s.speaker === "me" ? "" : "ai-text"}>{s.text}</span>
+                  </p>
+                ))}
+              </div>
             )}
           </div>
         </section>

--- a/desktop/src/components/Onboarding.tsx
+++ b/desktop/src/components/Onboarding.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useAppStore } from "@/store/app";
+
+const STEPS = [
+  {
+    title: "No bot joins the call",
+    body: "Bagrry listens to your mic and system audio on this machine. Grant capture when Windows asks, then record with Ctrl+Shift+R.",
+  },
+  {
+    title: "Your notes stay yours",
+    body: "Jot shorthand during the meeting. After you stop, Enhance expands it in gray, with citations back to the transcript.",
+  },
+  {
+    title: "Bring your own Groq key",
+    body: "Whisper and Llama run through your key. Without one, search and heuristic enhance still work offline.",
+  },
+];
+
+export function Onboarding() {
+  const open = useAppStore((s) => s.onboardingOpen);
+  const finish = useAppStore((s) => s.finishOnboarding);
+  const setPage = useAppStore((s) => s.setPage);
+  const [step, setStep] = useState(0);
+  if (!open) return null;
+  const s = STEPS[step];
+  const last = step === STEPS.length - 1;
+  return (
+    <div className="fixed inset-0 z-[70] flex items-center justify-center bg-[#1c1914]/30 px-4 backdrop-blur-[2px]">
+      <div className="paper-card w-full max-w-md rounded-2xl border border-[#e4dfd3] p-7">
+        <p className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+          {step + 1} / {STEPS.length}
+        </p>
+        <h2 className="font-display mt-2 text-3xl">{s.title}</h2>
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{s.body}</p>
+        <div className="mt-6 flex justify-between">
+          <Button variant="ghost" className="rounded-full" onClick={finish}>
+            Skip
+          </Button>
+          <Button
+            className="rounded-full"
+            onClick={() => {
+              if (last) {
+                finish();
+                setPage("notes");
+              } else {
+                setStep(step + 1);
+              }
+            }}
+          >
+            {last ? "Open notepad" : "Next"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/components/pages.tsx
+++ b/desktop/src/components/pages.tsx
@@ -192,9 +192,38 @@ export function CalendarPage() {
 
 export function ActionsPage() {
   const actions = useQuery({ queryKey: ["actions"], queryFn: api.listActionItems });
+  const meetings = useQuery({ queryKey: ["meetings", null], queryFn: () => api.listMeetings(null) });
   const selectMeeting = useAppStore((s) => s.selectMeeting);
+  const qc = useQueryClient();
+  const [task, setTask] = useState("");
+  const [owner, setOwner] = useState("");
+  const [meetingId, setMeetingId] = useState("");
   return (
     <PageFrame kicker="Follow-through" title="Action items" subtitle="Owners, deadlines, and the meeting they came from.">
+      <div className="mb-6 flex flex-wrap gap-2">
+        <input className="h-9 flex-1 rounded-full border px-3 text-sm" placeholder="Task" value={task} onChange={(e) => setTask(e.target.value)} />
+        <input className="h-9 w-40 rounded-full border px-3 text-sm" placeholder="Owner" value={owner} onChange={(e) => setOwner(e.target.value)} />
+        <select className="h-9 rounded-full border px-3 text-sm" value={meetingId} onChange={(e) => setMeetingId(e.target.value)}>
+          <option value="">Meeting</option>
+          {meetings.data?.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.title}
+            </option>
+          ))}
+        </select>
+        <Button
+          size="sm"
+          className="rounded-full"
+          onClick={async () => {
+            if (!task || !meetingId) return;
+            await api.addActionItem(meetingId, task, owner || null);
+            setTask("");
+            qc.invalidateQueries({ queryKey: ["actions"] });
+          }}
+        >
+          Add
+        </Button>
+      </div>
       <ul className="space-y-2">
         {(actions.data ?? []).map((a) => (
           <li key={a.id}>
@@ -214,6 +243,145 @@ export function ActionsPage() {
           </li>
         ))}
       </ul>
+    </PageFrame>
+  );
+}
+
+export function TemplatesPage() {
+  const templates = useQuery({ queryKey: ["templates"], queryFn: api.listTemplates });
+  const recipes = useQuery({ queryKey: ["recipes"], queryFn: api.listRecipes });
+  const qc = useQueryClient();
+  const [name, setName] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [sections, setSections] = useState("Wins, Challenges, Next Steps");
+  const [rname, setRname] = useState("");
+  const [rprompt, setRprompt] = useState("");
+  return (
+    <PageFrame
+      kicker="Enhance"
+      title="Templates & recipes"
+      subtitle="1-on-1s, discovery, research, retros — or write your own structure. Recipes run after the call."
+    >
+      <div className="grid gap-3 md:grid-cols-2">
+        {templates.data?.map((t) => (
+          <article key={t.id} className="rounded-2xl border border-border bg-card p-5">
+            <p className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">Template</p>
+            <h3 className="font-display mt-1 text-xl">{t.name}</h3>
+            <p className="mt-2 text-sm text-muted-foreground">{t.prompt_template}</p>
+          </article>
+        ))}
+      </div>
+      <div className="paper-card mt-8 rounded-2xl border border-border p-5">
+        <h3 className="font-display text-xl">Custom template</h3>
+        <div className="mt-3 grid gap-2">
+          <input className="h-9 rounded-full border px-3 text-sm" placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} />
+          <input className="h-9 rounded-full border px-3 text-sm" placeholder="Sections, comma separated" value={sections} onChange={(e) => setSections(e.target.value)} />
+          <textarea className="min-h-20 rounded-xl border p-3 text-sm" placeholder="Enhancement instructions" value={prompt} onChange={(e) => setPrompt(e.target.value)} />
+          <Button
+            className="w-fit rounded-full"
+            onClick={async () => {
+              if (!name || !prompt) return;
+              const structure = JSON.stringify({
+                sections: sections.split(",").map((s) => s.trim()).filter(Boolean),
+              });
+              await api.saveCustomTemplate(name, prompt, structure);
+              setName("");
+              setPrompt("");
+              qc.invalidateQueries({ queryKey: ["templates"] });
+            }}
+          >
+            Save template
+          </Button>
+        </div>
+      </div>
+      <h3 className="font-display mt-10 text-2xl">Recipes</h3>
+      <div className="mt-3 grid gap-3 md:grid-cols-2">
+        {recipes.data?.map((r) => (
+          <article key={r.id} className="rounded-2xl border border-border bg-card p-5">
+            <h4 className="font-medium">{r.name}</h4>
+            <p className="mt-1 text-sm text-muted-foreground">{r.prompt_template}</p>
+          </article>
+        ))}
+      </div>
+      <div className="mt-4 grid gap-2">
+        <input className="h-9 rounded-full border px-3 text-sm" placeholder="Recipe name" value={rname} onChange={(e) => setRname(e.target.value)} />
+        <textarea className="min-h-16 rounded-xl border p-3 text-sm" placeholder="What should it produce?" value={rprompt} onChange={(e) => setRprompt(e.target.value)} />
+        <Button
+          className="w-fit rounded-full"
+          variant="outline"
+          onClick={async () => {
+            if (!rname || !rprompt) return;
+            await api.saveCustomRecipe(rname, rprompt);
+            setRname("");
+            setRprompt("");
+            qc.invalidateQueries({ queryKey: ["recipes"] });
+          }}
+        >
+          Save recipe
+        </Button>
+      </div>
+    </PageFrame>
+  );
+}
+
+export function WorkspacePage() {
+  const [name, setName] = useState("Personal");
+  const [plan, setPlan] = useState("basic");
+  const [optOut, setOptOut] = useState(true);
+  const [overlay, setOverlay] = useState(true);
+  const [lang, setLang] = useState("en");
+  const [saved, setSaved] = useState("");
+  useEffect(() => {
+    api.getSetting("workspace_name").then((v) => v && setName(v)).catch(() => undefined);
+    api.getSetting("plan").then((v) => v && setPlan(v)).catch(() => undefined);
+    api.getSetting("training_opt_out").then((v) => setOptOut(v !== "0")).catch(() => undefined);
+    api.getSetting("overlay_enabled").then((v) => setOverlay(v !== "0")).catch(() => undefined);
+    api.getSetting("language").then((v) => v && setLang(v)).catch(() => undefined);
+  }, []);
+  async function save() {
+    await api.setSetting("workspace_name", name);
+    await api.setSetting("plan", plan);
+    await api.setSetting("training_opt_out", optOut ? "1" : "0");
+    await api.setSetting("overlay_enabled", overlay ? "1" : "0");
+    await api.setSetting("language", lang);
+    setSaved("Saved on this machine");
+  }
+  return (
+    <PageFrame
+      kicker="Account"
+      title="Workspace"
+      subtitle="Plan, privacy, and how Bagrry shows up in the room. Everything here is local."
+    >
+      <div className="max-w-lg space-y-4">
+        <label className="block text-xs font-medium">Workspace name</label>
+        <input className="h-10 w-full rounded-full border px-4 text-sm" value={name} onChange={(e) => setName(e.target.value)} />
+        <label className="block text-xs font-medium">Plan</label>
+        <select className="h-10 w-full rounded-full border px-4 text-sm" value={plan} onChange={(e) => setPlan(e.target.value)}>
+          <option value="basic">Basic — $0</option>
+          <option value="business">Business — $14</option>
+          <option value="enterprise">Enterprise — $35</option>
+        </select>
+        <label className="block text-xs font-medium">Note language</label>
+        <select className="h-10 w-full rounded-full border px-4 text-sm" value={lang} onChange={(e) => setLang(e.target.value)}>
+          <option value="en">English</option>
+          <option value="es">Spanish</option>
+          <option value="fr">French</option>
+          <option value="de">German</option>
+          <option value="ja">Japanese</option>
+        </select>
+        <label className="flex items-center gap-2 text-sm">
+          <input type="checkbox" checked={optOut} onChange={(e) => setOptOut(e.target.checked)} />
+          Opt out of model training
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input type="checkbox" checked={overlay} onChange={(e) => setOverlay(e.target.checked)} />
+          Show “Bagrry is recording” watermark
+        </label>
+        <Button className="rounded-full" onClick={save}>
+          Save workspace
+        </Button>
+        {saved && <p className="text-xs text-primary">{saved}</p>}
+      </div>
     </PageFrame>
   );
 }

--- a/desktop/src/lib/api.ts
+++ b/desktop/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import type {
   ActionItem,
+  Attachment,
   CalendarEvent,
   Company,
   DbStatus,
@@ -74,3 +75,28 @@ export const saveAttachmentText = (meetingId: string, filename: string, extracte
 export const createFolder = (name: string) => invoke<Folder>("create_folder", { name });
 export const saveCustomTemplate = (name: string, promptTemplate: string, structureJson: string) =>
   invoke<void>("save_custom_template", { name, promptTemplate, structureJson });
+export const deleteMeeting = (id: string) => invoke<void>("delete_meeting", { id });
+export const moveMeeting = (id: string, folderId?: string | null) =>
+  invoke<void>("move_meeting", { id, folderId: folderId ?? null });
+export const setFolderShared = (id: string, isShared: boolean) =>
+  invoke<void>("set_folder_shared", { id, isShared });
+export const listMeetingAttendees = (meetingId: string) =>
+  invoke<Person[]>("list_meeting_attendees", { meetingId });
+export const addMeetingAttendee = (meetingId: string, personId: string) =>
+  invoke<void>("add_meeting_attendee", { meetingId, personId });
+export const listAttachments = (meetingId: string) =>
+  invoke<Attachment[]>("list_attachments", { meetingId });
+export const saveCustomRecipe = (name: string, promptTemplate: string) =>
+  invoke<void>("save_custom_recipe", { name, promptTemplate });
+export const addActionItem = (
+  meetingId: string,
+  task: string,
+  owner?: string | null,
+  deadline?: string | null,
+) =>
+  invoke<ActionItem>("add_action_item", {
+    meetingId,
+    task,
+    owner: owner ?? null,
+    deadline: deadline ?? null,
+  });

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -120,6 +120,13 @@ export type ActionItem = {
   deadline: string | null;
 };
 
+export type Attachment = {
+  id: string;
+  meeting_id: string;
+  filename: string;
+  extracted_text: string | null;
+};
+
 export type Page =
   | "landing"
   | "dashboard"
@@ -129,6 +136,8 @@ export type Page =
   | "companies"
   | "calendar"
   | "actions"
+  | "templates"
+  | "workspace"
   | "pricing"
   | "integrations"
   | "settings";

--- a/desktop/src/store/app.ts
+++ b/desktop/src/store/app.ts
@@ -3,6 +3,7 @@ import type { Page, RecState, RecStatus, VuLevels } from "@/lib/types";
 import { normalizeRecStatus } from "@/lib/types";
 
 const ENTERED_KEY = "bagrry.entered";
+const ONBOARD_KEY = "bagrry.onboarded";
 
 function initialPage(): Page {
   try {
@@ -23,6 +24,8 @@ type AppState = {
   liveOpen: boolean;
   chatOpen: boolean;
   overlayOn: boolean;
+  paletteOpen: boolean;
+  onboardingOpen: boolean;
   setPage: (page: Page) => void;
   enterWorkspace: (page?: Page) => void;
   selectMeeting: (id: string | null) => void;
@@ -32,6 +35,8 @@ type AppState = {
   setLiveOpen: (v: boolean) => void;
   setChatOpen: (v: boolean) => void;
   setOverlayOn: (v: boolean) => void;
+  setPaletteOpen: (v: boolean) => void;
+  finishOnboarding: () => void;
 };
 
 export const useAppStore = create<AppState>((set) => ({
@@ -45,14 +50,24 @@ export const useAppStore = create<AppState>((set) => ({
   liveOpen: false,
   chatOpen: false,
   overlayOn: false,
+  paletteOpen: false,
+  onboardingOpen: (() => {
+    try {
+      return localStorage.getItem(ENTERED_KEY) === "1" && localStorage.getItem(ONBOARD_KEY) !== "1";
+    } catch {
+      return false;
+    }
+  })(),
   setPage: (page) => set({ page }),
   enterWorkspace: (page = "dashboard") => {
+    let showOnboard = false;
     try {
       localStorage.setItem(ENTERED_KEY, "1");
+      showOnboard = localStorage.getItem(ONBOARD_KEY) !== "1";
     } catch {
       /* ignore */
     }
-    set({ page });
+    set({ page, onboardingOpen: showOnboard });
   },
   selectMeeting: (id) => set({ selectedMeetingId: id, page: "notes" }),
   setFolderId: (id) => set({ folderId: id }),
@@ -69,4 +84,13 @@ export const useAppStore = create<AppState>((set) => ({
   setLiveOpen: (liveOpen) => set({ liveOpen }),
   setChatOpen: (chatOpen) => set({ chatOpen }),
   setOverlayOn: (overlayOn) => set({ overlayOn }),
+  setPaletteOpen: (paletteOpen) => set({ paletteOpen }),
+  finishOnboarding: () => {
+    try {
+      localStorage.setItem(ONBOARD_KEY, "1");
+    } catch {
+      /* ignore */
+    }
+    set({ onboardingOpen: false });
+  },
 }));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Second product pass on latest `main` — more of the notepad SaaS surface, not just chrome.

**Command palette** — `Ctrl+K` jumps pages, searches notes, and routes into Ask.

**Onboarding** — Three-step first-run overlay (no bot, enhance in gray, BYOK Groq).

**Templates & recipes** — Dedicated page for built-ins plus custom templates/recipes persisted in SQLite.

**Workspace** — Plan (Basic / Business / Enterprise), language, training opt-out, recording watermark.

**Notes** — Attendee chips, move between folders, shared-folder toggle, delete, drag-drop text attachments, Enhanced vs Transcript tabs.

**Actions** — Create owner/task rows linked to a meeting.

**Landing** — FAQ on training, consent, plans, and local data.

New Rust IPC: `delete_meeting`, `move_meeting`, `set_folder_shared`, `list_meeting_attendees`, `add_meeting_attendee`, `list_attachments`, `save_custom_recipe`, `add_action_item`.

Frontend `tsc && vite build` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

