### PR TITLE
Add quiet primitive-level motion to chrome and menus

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -19,8 +19,7 @@ import { ChatPage } from "@/components/pages/ChatPage";
 import { SpacePage } from "@/components/pages/SpacePage";
 import { SharedPage } from "@/components/pages/SharedPage";
 import { SettingsPage } from "@/components/pages/SettingsPage";
-
-const SNAPPY = { duration: 0.14, ease: [0.22, 1, 0.36, 1] as const };
+import { layoutTween, SIDEBAR_WIDTH, snappy } from "@/lib/motion";
 
 export default function App() {
   const route = useAppStore((s) => s.route);
@@ -32,19 +31,22 @@ export default function App() {
   useShowWindowWhenReady();
 
   return (
-    <MotionConfig reducedMotion="user" transition={SNAPPY}>
+    <MotionConfig reducedMotion="user">
       <TooltipProvider delayDuration={350} skipDelayDuration={200}>
         <div className="flex h-full w-full overflow-hidden bg-bg text-text">
           <AnimatePresence initial={false}>
             {sidebarOpen && (
               <motion.div
                 key="sidebar"
-                initial={{ opacity: 0, x: -10 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0, x: -10 }}
-                className="h-full"
+                initial={{ width: 0 }}
+                animate={{ width: SIDEBAR_WIDTH }}
+                exit={{ width: 0 }}
+                transition={layoutTween}
+                className="relative h-full shrink-0 overflow-hidden"
               >
-                <Sidebar />
+                <div className="absolute inset-y-0 left-0 h-full" style={{ width: SIDEBAR_WIDTH }}>
+                  <Sidebar />
+                </div>
               </motion.div>
             )}
           </AnimatePresence>
@@ -52,13 +54,14 @@ export default function App() {
           <div className="flex min-w-0 flex-1 flex-col bg-bg">
             <TitleBar />
             <main className="relative min-h-0 flex-1 overflow-hidden">
-              <AnimatePresence mode="popLayout" initial={false}>
+              <AnimatePresence mode="sync" initial={false}>
                 <motion.div
                   key={routeKey(route)}
-                  initial={{ opacity: 0, y: 8 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -6 }}
-                  className="h-full min-h-0"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={snappy}
+                  className="absolute inset-0"
                 >
                   {route.kind === "home" && <HomePage />}
                   {route.kind === "shared" && <SharedPage />}

--- a/desktop/src/components/Onboarding.tsx
+++ b/desktop/src/components/Onboarding.tsx
@@ -7,6 +7,8 @@ import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { toast } from "@/components/ui/toast";
+import { AnimatePresence, motion } from "framer-motion";
+import { snappy } from "@/lib/motion";
 
 const STEPS = [
   {
@@ -51,48 +53,58 @@ export function Onboarding() {
   return (
     <Dialog open={open} onOpenChange={(next) => !next && finish()}>
       <DialogContent showClose={false} className="max-w-[420px]">
-        {isLastStep ? (
-          <div>
-            <div className="mb-4 grid size-9 place-items-center rounded-xl bg-accent-subtle text-accent">
-              <KeyRound className="size-4" />
-            </div>
-            <h2 className="font-display text-xl font-semibold text-text">Almost there</h2>
-            <p className="mt-1 text-[13px] text-muted">
-              Transcription and summaries run through Groq. You can add the key later in Settings.
-            </p>
+        <AnimatePresence mode="wait" initial={false}>
+          <motion.div
+            key={isLastStep ? "setup" : step}
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={snappy}
+          >
+            {isLastStep ? (
+              <div>
+                <div className="mb-4 grid size-9 place-items-center rounded-xl bg-accent-subtle text-accent">
+                  <KeyRound className="size-4" />
+                </div>
+                <h2 className="font-display text-xl font-semibold text-text">Almost there</h2>
+                <p className="mt-1 text-[13px] text-muted">
+                  Transcription and summaries run through Groq. You can add the key later in Settings.
+                </p>
 
-            <div className="mt-4 space-y-3">
-              <Input placeholder="Your name" value={name} onChange={(e) => setName(e.target.value)} />
-              <Input
-                type="password"
-                placeholder="Groq API key (optional)"
-                value={groqKey}
-                onChange={(e) => setGroqKey(e.target.value)}
+                <div className="mt-4 space-y-3">
+                  <Input placeholder="Your name" value={name} onChange={(e) => setName(e.target.value)} />
+                  <Input
+                    type="password"
+                    placeholder="Groq API key (optional)"
+                    value={groqKey}
+                    onChange={(e) => setGroqKey(e.target.value)}
+                  />
+                </div>
+
+                <div className="mt-5 flex items-center justify-between">
+                  <Button variant="ghost" size="md" onClick={finish}>
+                    Skip
+                  </Button>
+                  <Button
+                    variant="solid"
+                    size="md"
+                    loading={complete.isPending}
+                    onClick={() => complete.mutate()}
+                  >
+                    Start using Bagrry
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <Step
+                index={step}
+                onNext={() => setStep((s) => s + 1)}
+                onSkip={finish}
+                total={STEPS.length}
               />
-            </div>
-
-            <div className="mt-5 flex items-center justify-between">
-              <Button variant="ghost" size="md" onClick={finish}>
-                Skip
-              </Button>
-              <Button
-                variant="solid"
-                size="md"
-                loading={complete.isPending}
-                onClick={() => complete.mutate()}
-              >
-                Start using Bagrry
-              </Button>
-            </div>
-          </div>
-        ) : (
-          <Step
-            index={step}
-            onNext={() => setStep((s) => s + 1)}
-            onSkip={finish}
-            total={STEPS.length}
-          />
-        )}
+            )}
+          </motion.div>
+        </AnimatePresence>
       </DialogContent>
     </Dialog>
   );
@@ -125,7 +137,11 @@ function Step({
           {Array.from({ length: total + 1 }, (_, i) => (
             <span
               key={i}
-              className={i === index ? "h-1 w-4 rounded-full bg-accent" : "size-1 rounded-full bg-border-strong"}
+              className={
+                i === index
+                  ? "h-1 w-4 rounded-full bg-accent transition-all duration-150"
+                  : "size-1 rounded-full bg-border-strong transition-all duration-150"
+              }
             />
           ))}
         </div>

--- a/desktop/src/components/layout/Sidebar.tsx
+++ b/desktop/src/components/layout/Sidebar.tsx
@@ -37,8 +37,8 @@ import {
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-
-const SIDEBAR_WIDTH = 208;
+import { SIDEBAR_WIDTH, layoutTween } from "@/lib/motion";
+import { AnimatePresence, motion } from "framer-motion";
 
 export function Sidebar() {
   const route = useAppStore((s) => s.route);
@@ -118,28 +118,38 @@ export function Sidebar() {
           }
         />
 
-        {chatExpanded && sessions.length > 0 && (
-          <div className="mb-1">
-            {sessions.slice(0, 6).map((session) => (
-              <button
-                key={session.id}
-                type="button"
-                onClick={() => navigate({ kind: "chat", sessionId: session.id })}
-                className={cn(
-                  "flex h-7 w-full items-center gap-2 rounded-lg pl-8 pr-2 text-left text-[13px] transition-colors",
-                  route.kind === "chat" && route.sessionId === session.id
-                    ? "bg-selected text-text"
-                    : "text-muted hover:bg-hover hover:text-text",
-                )}
-              >
-                <span className="min-w-0 flex-1 truncate">{session.title || "New chat"}</span>
-                <span className="shrink-0 text-[11px] text-subtle">
-                  {formatRelative(session.updated_at)}
-                </span>
-              </button>
-            ))}
-          </div>
-        )}
+        <AnimatePresence initial={false}>
+          {chatExpanded && sessions.length > 0 && (
+            <motion.div
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: "auto", opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={layoutTween}
+              className="overflow-hidden"
+            >
+              <div className="mb-1">
+                {sessions.slice(0, 6).map((session) => (
+                  <button
+                    key={session.id}
+                    type="button"
+                    onClick={() => navigate({ kind: "chat", sessionId: session.id })}
+                    className={cn(
+                      "flex h-7 w-full items-center gap-2 rounded-lg pl-8 pr-2 text-left text-[13px] transition-colors",
+                      route.kind === "chat" && route.sessionId === session.id
+                        ? "bg-selected text-text"
+                        : "text-muted hover:bg-hover hover:text-text",
+                    )}
+                  >
+                    <span className="min-w-0 flex-1 truncate">{session.title || "New chat"}</span>
+                    <span className="shrink-0 text-[11px] text-subtle">
+                      {formatRelative(session.updated_at)}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
 
         <div className="mt-4 px-2 pb-1 text-[11px] font-semibold text-subtle">Spaces</div>
 

--- a/desktop/src/components/layout/TitleBar.tsx
+++ b/desktop/src/components/layout/TitleBar.tsx
@@ -7,6 +7,8 @@ import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
 import { WindowControls } from "./WindowControls";
 import { useCreateNote } from "@/hooks/useCreateNote";
+import { AnimatePresence, motion } from "framer-motion";
+import { snappy } from "@/lib/motion";
 
 /**
  * The one horizontal strip at the top of the content column. Everything that
@@ -29,18 +31,28 @@ export function TitleBar() {
       className="flex h-11 shrink-0 items-center gap-2 pl-3 pr-0"
     >
       <div className="flex items-center gap-0.5 rounded-lg border border-border bg-surface p-0.5">
-        {history.length > 0 && (
-          <Tooltip label="Back" shortcut="Alt+←">
-            <button
-              type="button"
-              aria-label="Back"
-              onClick={back}
-              className="grid size-6 place-items-center rounded-md text-muted transition-colors hover:bg-hover hover:text-text"
+        <AnimatePresence initial={false}>
+          {history.length > 0 && (
+            <motion.div
+              initial={{ width: 0, opacity: 0 }}
+              animate={{ width: 24, opacity: 1 }}
+              exit={{ width: 0, opacity: 0 }}
+              transition={snappy}
+              className="overflow-hidden"
             >
-              <ChevronLeft className="size-3.5" />
-            </button>
-          </Tooltip>
-        )}
+              <Tooltip label="Back" shortcut="Alt+←">
+                <button
+                  type="button"
+                  aria-label="Back"
+                  onClick={back}
+                  className="grid size-6 place-items-center rounded-md text-muted transition-colors hover:bg-hover hover:text-text"
+                >
+                  <ChevronLeft className="size-3.5" />
+                </button>
+              </Tooltip>
+            </motion.div>
+          )}
+        </AnimatePresence>
         <Tooltip label={sidebarOpen ? "Hide sidebar" : "Show sidebar"} shortcut="Ctrl+\">
           <button
             type="button"
@@ -56,7 +68,11 @@ export function TitleBar() {
         </Tooltip>
       </div>
 
-      {recState !== "idle" && <RecordingPill />}
+      {recState !== "idle" && (
+        <motion.div initial={{ opacity: 0, scale: 0.96 }} animate={{ opacity: 1, scale: 1 }} transition={snappy}>
+          <RecordingPill />
+        </motion.div>
+      )}
 
       <div data-tauri-drag-region className="h-full flex-1" />
 

--- a/desktop/src/components/notes/TranscriptPanel.tsx
+++ b/desktop/src/components/notes/TranscriptPanel.tsx
@@ -8,6 +8,8 @@ import { useAppStore } from "@/store/app";
 import { toast } from "@/components/ui/toast";
 import { Tooltip } from "@/components/ui/tooltip";
 import { RecordingControls } from "./RecordingControls";
+import { AnimatePresence, motion } from "framer-motion";
+import { snappy } from "@/lib/motion";
 
 /**
  * The floating transcript card that sits over the editor while a note is live.
@@ -52,119 +54,133 @@ export function TranscriptPanel({ noteId }: { noteId: string }) {
     }
   };
 
-  if (minimized) {
-    return (
-      <div className="pointer-events-auto mx-auto w-full max-w-[576px]">
-        <div className="flex items-center gap-2 rounded-full border border-border bg-surface-2 px-3 py-1.5 shadow-lg">
-          <RecordingControls noteId={noteId} compact />
-          <button
-            type="button"
-            onClick={() => setMinimized(false)}
-            className="flex-1 truncate text-left text-xs text-muted transition-colors hover:text-text"
-          >
-            {recState === "recording" ? "Transcribing…" : "Transcript"}
-            {startedAt && recState !== "idle" && (
-              <span className="ml-2 tabular text-subtle">
-                <Elapsed startedAt={startedAt} />
-              </span>
-            )}
-          </button>
-          <Tooltip label="Close">
-            <button
-              type="button"
-              aria-label="Close transcript"
-              onClick={() => setOpen(false)}
-              className="grid size-5 place-items-center rounded text-subtle transition-colors hover:bg-hover hover:text-text"
-            >
-              <X className="size-3.5" />
-            </button>
-          </Tooltip>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="pointer-events-auto mx-auto w-full max-w-[576px]">
-      <div className="overflow-hidden rounded-2xl border border-border bg-surface-2 shadow-xl">
-        <div className="flex items-center gap-2 px-3 py-2">
-          {searching ? (
-            <input
-              autoFocus
-              value={query}
-              placeholder="Search transcript"
-              onChange={(e) => setQuery(e.target.value)}
-              onBlur={() => !query && setSearching(false)}
-              onKeyDown={(e) => {
-                if (e.key === "Escape") {
-                  setQuery("");
-                  setSearching(false);
-                }
-              }}
-              className="h-6 flex-1 bg-transparent text-xs text-text outline-none placeholder:text-subtle"
-            />
-          ) : (
-            <>
+      <AnimatePresence mode="wait" initial={false}>
+        {minimized ? (
+          <motion.div
+            key="minimized"
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 4 }}
+            transition={snappy}
+          >
+            <div className="flex items-center gap-2 rounded-full border border-border bg-surface-2 px-3 py-1.5 shadow-lg">
+              <RecordingControls noteId={noteId} compact />
               <button
                 type="button"
-                aria-label="Search transcript"
-                onClick={() => setSearching(true)}
-                className="grid size-5 place-items-center rounded text-subtle transition-colors hover:bg-hover hover:text-text"
+                onClick={() => setMinimized(false)}
+                className="flex-1 truncate text-left text-xs text-muted transition-colors hover:text-text"
               >
-                <Search className="size-3.5" />
-              </button>
-              <div className="flex-1" />
-            </>
-          )}
-
-          <PanelAction label="Report a problem" icon={ThumbsDown} onClick={() => toast.info("Thanks — feedback noted")} />
-          <PanelAction label="Copy transcript" icon={Copy} onClick={() => void copyAll()} />
-          <PanelAction label="Minimise" icon={Minus} onClick={() => setMinimized(true)} />
-        </div>
-
-        <div ref={scrollRef} className="h-[240px] overflow-y-auto px-4">
-          {filtered.length === 0 ? (
-            <div className="grid h-full place-items-center text-center">
-              <p className="text-[13px] text-subtle">
-                {query
-                  ? "No matching lines"
-                  : recState === "recording"
-                    ? "Transcript starting…"
-                    : "Nothing transcribed yet"}
-              </p>
-            </div>
-          ) : (
-            <div className="space-y-2 py-2">
-              {filtered.map((segment) => (
-                <div key={segment.id} className="flex gap-2 text-[13px] leading-relaxed">
-                  <span
-                    className={cn(
-                      "shrink-0 pt-0.5 text-[10px] font-semibold uppercase tracking-wide",
-                      segment.speaker === "me" ? "text-accent" : "text-subtle",
-                    )}
-                  >
-                    {segment.speaker === "me" ? "Me" : "Them"}
+                {recState === "recording" ? "Transcribing…" : "Transcript"}
+                {startedAt && recState !== "idle" && (
+                  <span className="ml-2 tabular text-subtle">
+                    <Elapsed startedAt={startedAt} />
                   </span>
-                  <span className="text-text">{segment.text}</span>
-                </div>
-              ))}
+                )}
+              </button>
+              <Tooltip label="Close">
+                <button
+                  type="button"
+                  aria-label="Close transcript"
+                  onClick={() => setOpen(false)}
+                  className="grid size-5 place-items-center rounded text-subtle transition-colors hover:bg-hover hover:text-text"
+                >
+                  <X className="size-3.5" />
+                </button>
+              </Tooltip>
             </div>
-          )}
-        </div>
+          </motion.div>
+        ) : (
+          <motion.div
+            key="expanded"
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 6 }}
+            transition={snappy}
+          >
+            <div className="overflow-hidden rounded-2xl border border-border bg-surface-2 shadow-xl">
+              <div className="flex items-center gap-2 px-3 py-2">
+                {searching ? (
+                  <input
+                    autoFocus
+                    value={query}
+                    placeholder="Search transcript"
+                    onChange={(e) => setQuery(e.target.value)}
+                    onBlur={() => !query && setSearching(false)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Escape") {
+                        setQuery("");
+                        setSearching(false);
+                      }
+                    }}
+                    className="h-6 flex-1 bg-transparent text-xs text-text outline-none placeholder:text-subtle"
+                  />
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      aria-label="Search transcript"
+                      onClick={() => setSearching(true)}
+                      className="grid size-5 place-items-center rounded text-subtle transition-colors hover:bg-hover hover:text-text"
+                    >
+                      <Search className="size-3.5" />
+                    </button>
+                    <div className="flex-1" />
+                  </>
+                )}
 
-        <div className="mx-3 mb-2 rounded-lg bg-hover px-3 py-1.5 text-center text-[11px] text-subtle">
-          Always get consent when transcribing others.{" "}
-          <button type="button" className="text-muted underline-offset-2 hover:underline">
-            Learn more
-          </button>
-        </div>
+                <PanelAction label="Report a problem" icon={ThumbsDown} onClick={() => toast.info("Thanks — feedback noted")} />
+                <PanelAction label="Copy transcript" icon={Copy} onClick={() => void copyAll()} />
+                <PanelAction label="Minimise" icon={Minus} onClick={() => setMinimized(true)} />
+              </div>
 
-        <div className="border-t border-border px-3 py-2">
-          <RecordingControls noteId={noteId} />
-        </div>
-      </div>
+              <div ref={scrollRef} className="h-[240px] overflow-y-auto px-4">
+                {filtered.length === 0 ? (
+                  <div className="grid h-full place-items-center text-center">
+                    <p className="text-[13px] text-subtle">
+                      {query
+                        ? "No matching lines"
+                        : recState === "recording"
+                          ? "Transcript starting…"
+                          : "Nothing transcribed yet"}
+                    </p>
+                  </div>
+                ) : (
+                  <div className="space-y-2 py-2">
+                    {filtered.map((segment) => (
+                      <div key={segment.id} className="flex gap-2 text-[13px] leading-relaxed">
+                        <span
+                          className={cn(
+                            "shrink-0 pt-0.5 text-[10px] font-semibold uppercase tracking-wide",
+                            segment.speaker === "me" ? "text-accent" : "text-subtle",
+                          )}
+                        >
+                          {segment.speaker === "me" ? "Me" : "Them"}
+                        </span>
+                        <span className="text-text">{segment.text}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
 
-      <p className="mt-2 text-center text-[11px] text-subtle">Bagrry uses AI and can make mistakes.</p>
+              <div className="mx-3 mb-2 rounded-lg bg-hover px-3 py-1.5 text-center text-[11px] text-subtle">
+                Always get consent when transcribing others.{" "}
+                <button type="button" className="text-muted underline-offset-2 hover:underline">
+                  Learn more
+                </button>
+              </div>
+
+              <div className="border-t border-border px-3 py-2">
+                <RecordingControls noteId={noteId} />
+              </div>
+            </div>
+
+            <p className="mt-2 text-center text-[11px] text-subtle">Bagrry uses AI and can make mistakes.</p>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/desktop/src/components/pages/NotePage.tsx
+++ b/desktop/src/components/pages/NotePage.tsx
@@ -32,6 +32,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { AnimatePresence, motion } from "framer-motion";
+import { snappy } from "@/lib/motion";
 
 type Tab = "notes" | "enhanced";
 
@@ -256,44 +258,73 @@ export function NotePage({ noteId }: { noteId: string }) {
           </div>
 
           <div className="mt-5">
-            {tab === "enhanced" && hasEnhanced ? (
-              <EnhancedNotes noteId={noteId} json={note.enhanced_notes_json} />
-            ) : (
-              <NoteEditor
-                noteId={noteId}
-                initialContent={note.scratchpad_raw}
-                onSave={(html) => saveBody.mutate(html)}
-                onSelectionChange={setSelection}
-              />
-            )}
+            <AnimatePresence mode="wait" initial={false}>
+              <motion.div
+                key={tab === "enhanced" && hasEnhanced ? "enhanced" : "notes"}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={snappy}
+              >
+                {tab === "enhanced" && hasEnhanced ? (
+                  <EnhancedNotes noteId={noteId} json={note.enhanced_notes_json} />
+                ) : (
+                  <NoteEditor
+                    noteId={noteId}
+                    initialContent={note.scratchpad_raw}
+                    onSave={(html) => saveBody.mutate(html)}
+                    onSelectionChange={setSelection}
+                  />
+                )}
+              </motion.div>
+            </AnimatePresence>
           </div>
         </div>
       </div>
 
-      {selection && tab === "notes" && (
-        <SelectionToolbar
-          busy={reprompt.isPending}
-          onInstruction={(instruction) => reprompt.mutate(instruction)}
-        />
-      )}
+      <AnimatePresence>
+        {selection && tab === "notes" && (
+          <SelectionToolbar
+            busy={reprompt.isPending}
+            onInstruction={(instruction) => reprompt.mutate(instruction)}
+          />
+        )}
+      </AnimatePresence>
 
       <div className="pointer-events-none absolute inset-x-0 bottom-0 px-6 pb-4">
-        {transcriptOpen ? (
-          <TranscriptPanel noteId={noteId} />
-        ) : (
-          <div className="pointer-events-auto mx-auto flex w-full max-w-[640px] items-center gap-2">
-            <div className="rounded-full border border-border bg-surface px-2.5 py-1.5 shadow-md">
-              <RecordingControls noteId={noteId} compact />
-            </div>
-            <AskBar
-              className="flex-1"
-              placeholder="Ask anything"
-              showModel={false}
-              busy={ask.isPending}
-              onSubmit={(value) => ask.mutate(value)}
-            />
-          </div>
-        )}
+        <AnimatePresence mode="wait" initial={false}>
+          {transcriptOpen ? (
+            <motion.div
+              key="transcript"
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 6 }}
+              transition={snappy}
+            >
+              <TranscriptPanel noteId={noteId} />
+            </motion.div>
+          ) : (
+            <motion.div
+              key="askbar"
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 6 }}
+              transition={snappy}
+              className="pointer-events-auto mx-auto flex w-full max-w-[640px] items-center gap-2"
+            >
+              <div className="rounded-full border border-border bg-surface px-2.5 py-1.5 shadow-md">
+                <RecordingControls noteId={noteId} compact />
+              </div>
+              <AskBar
+                className="flex-1"
+                placeholder="Ask anything"
+                showModel={false}
+                busy={ask.isPending}
+                onSubmit={(value) => ask.mutate(value)}
+              />
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
     </div>
   );
@@ -410,8 +441,14 @@ function SelectionToolbar({
   onInstruction: (instruction: string) => void;
 }) {
   return (
-    <div className="pointer-events-none absolute inset-x-0 top-3 flex justify-center">
-      <div className="pointer-events-auto flex items-center gap-1 rounded-full border border-border bg-elevated px-1.5 py-1 shadow-lg animate-slide-up">
+    <motion.div
+      initial={{ opacity: 0, y: -6 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -6 }}
+      transition={snappy}
+      className="pointer-events-none absolute inset-x-0 top-3 flex justify-center"
+    >
+      <div className="pointer-events-auto flex items-center gap-1 rounded-full border border-border bg-elevated px-1.5 py-1 shadow-lg">
         <Sparkles className="ml-1 size-3.5 text-accent" />
         {REWRITE_ACTIONS.map((action) => (
           <Button
@@ -425,6 +462,6 @@ function SelectionToolbar({
           </Button>
         ))}
       </div>
-    </div>
+    </motion.div>
   );
 }

--- a/desktop/src/components/pages/SettingsPage.tsx
+++ b/desktop/src/components/pages/SettingsPage.tsx
@@ -45,6 +45,8 @@ import {
   Switch,
 } from "@/components/ui/controls";
 import { toast } from "@/components/ui/toast";
+import { AnimatePresence, motion } from "framer-motion";
+import { snappy } from "@/lib/motion";
 
 type NavEntry = { tab: SettingsTab; label: string; icon: LucideIcon };
 
@@ -93,19 +95,28 @@ export function SettingsPage({ tab }: { tab: SettingsTab }) {
       </nav>
 
       <div className="min-h-0 flex-1 overflow-y-auto">
-        <div className="mx-auto w-full max-w-[620px] px-8 pb-16 pt-6">
-          {tab === "preferences" && <PreferencesTab />}
-          {tab === "profile" && <ProfileTab />}
-          {tab === "calendar" && <CalendarTab />}
-          {tab === "notifications" && <NotificationsTab />}
-          {tab === "connectors" && <ConnectorsTab />}
-          {tab === "help" && <HelpTab />}
-          {tab === "workspace-general" && <WorkspaceGeneralTab />}
-          {tab === "members" && <MembersTab />}
-          {tab === "spaces" && <SpacesTab />}
-          {tab === "analytics" && <AnalyticsTab />}
-          {tab === "billing" && <BillingTab />}
-        </div>
+        <AnimatePresence mode="wait" initial={false}>
+          <motion.div
+            key={tab}
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0 }}
+            transition={snappy}
+            className="mx-auto w-full max-w-[620px] px-8 pb-16 pt-6"
+          >
+            {tab === "preferences" && <PreferencesTab />}
+            {tab === "profile" && <ProfileTab />}
+            {tab === "calendar" && <CalendarTab />}
+            {tab === "notifications" && <NotificationsTab />}
+            {tab === "connectors" && <ConnectorsTab />}
+            {tab === "help" && <HelpTab />}
+            {tab === "workspace-general" && <WorkspaceGeneralTab />}
+            {tab === "members" && <MembersTab />}
+            {tab === "spaces" && <SpacesTab />}
+            {tab === "analytics" && <AnalyticsTab />}
+            {tab === "billing" && <BillingTab />}
+          </motion.div>
+        </AnimatePresence>
       </div>
     </div>
   );

--- a/desktop/src/components/ui/button.tsx
+++ b/desktop/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "relative inline-flex shrink-0 select-none items-center justify-center gap-1.5 whitespace-nowrap rounded-full font-medium outline-none transition-[background-color,color,border-color,box-shadow,opacity] duration-150 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:pointer-events-none disabled:opacity-45 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  "relative inline-flex shrink-0 select-none items-center justify-center gap-1.5 whitespace-nowrap rounded-full font-medium outline-none transition-[background-color,color,border-color,box-shadow,opacity,transform] duration-150 ease-out active:scale-[0.98] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:pointer-events-none disabled:opacity-45 disabled:active:scale-100 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/desktop/src/components/ui/controls.tsx
+++ b/desktop/src/components/ui/controls.tsx
@@ -16,7 +16,7 @@ export const Switch = React.forwardRef<
     <SwitchPrimitive.Root
       ref={ref}
       className={cn(
-        "peer inline-flex h-[22px] w-[38px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors",
+        "peer inline-flex h-[22px] w-[38px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-150",
         "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
         "data-[state=checked]:bg-accent data-[state=unchecked]:bg-border-strong",
         "disabled:cursor-not-allowed disabled:opacity-50",
@@ -26,7 +26,7 @@ export const Switch = React.forwardRef<
     >
       <SwitchPrimitive.Thumb
         className={cn(
-          "pointer-events-none block size-[18px] rounded-full bg-white shadow-sm ring-0 transition-transform",
+          "pointer-events-none block size-[18px] rounded-full bg-white shadow-sm ring-0 transition-transform duration-150 ease-out",
           "data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
         )}
       />
@@ -75,7 +75,7 @@ export const SelectContent = React.forwardRef<
         position={position}
         sideOffset={6}
         className={cn(
-          "z-50 min-w-[8rem] overflow-hidden rounded-xl border border-border bg-elevated p-1 text-[13px] shadow-lg animate-pop-in",
+          "z-50 min-w-[8rem] overflow-hidden rounded-xl border border-border bg-elevated p-1 text-[13px] shadow-lg ui-pop",
           "max-h-[min(24rem,var(--radix-select-content-available-height))]",
           className,
         )}

--- a/desktop/src/components/ui/dialog.tsx
+++ b/desktop/src/components/ui/dialog.tsx
@@ -17,11 +17,11 @@ export const DialogContent = React.forwardRef<
 >(function DialogContent({ className, children, showClose = true, bare = false, ...props }, ref) {
   return (
     <Primitive.Portal>
-      <Primitive.Overlay className="fixed inset-0 z-50 bg-overlay backdrop-blur-[2px] animate-fade-in" />
+      <Primitive.Overlay className="ui-overlay fixed inset-0 z-50 bg-overlay backdrop-blur-[2px]" />
       <Primitive.Content
         ref={ref}
         className={cn(
-          "fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 outline-none animate-pop-in",
+          "ui-dialog fixed left-1/2 top-1/2 z-50 w-full max-w-lg outline-none",
           !bare && "rounded-2xl border border-border bg-elevated p-5 shadow-xl",
           className,
         )}

--- a/desktop/src/components/ui/dropdown-menu.tsx
+++ b/desktop/src/components/ui/dropdown-menu.tsx
@@ -10,7 +10,7 @@ export const DropdownMenuSub = Primitive.Sub;
 export const DropdownMenuRadioGroup = Primitive.RadioGroup;
 
 const panelClass =
-  "z-50 min-w-[11rem] overflow-hidden rounded-xl border border-border bg-elevated p-1 text-[13px] shadow-lg animate-pop-in";
+  "ui-pop z-50 min-w-[11rem] overflow-hidden rounded-xl border border-border bg-elevated p-1 text-[13px] shadow-lg";
 
 export const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof Primitive.Content>,

--- a/desktop/src/components/ui/tooltip.tsx
+++ b/desktop/src/components/ui/tooltip.tsx
@@ -33,8 +33,7 @@ export function Tooltip({
           align={align}
           sideOffset={6}
           className={cn(
-            "z-[60] flex items-center gap-1.5 rounded-md border border-border bg-elevated px-2 py-1 text-[11px] font-medium text-text shadow-md",
-            "animate-pop-in",
+            "ui-pop z-[60] flex items-center gap-1.5 rounded-md border border-border bg-elevated px-2 py-1 text-[11px] font-medium text-text shadow-md",
           )}
         >
           {label}

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -10,6 +10,11 @@
 
 :root {
   color-scheme: light;
+  --motion-fast: 120ms;
+  --motion: 160ms;
+  --motion-layout: 200ms;
+  --motion-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --motion-in: cubic-bezier(0.4, 0, 1, 1);
 
   /* Surfaces, from furthest back to closest to the user */
   --bg: #f6f5f2;
@@ -302,23 +307,45 @@
   to { opacity: 1; }
 }
 
+@keyframes fade-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
 @keyframes pop-in {
-  from { opacity: 0; transform: scale(0.96) translateY(4px); }
-  to { opacity: 1; transform: scale(1) translateY(0); }
+  from { opacity: 0; transform: scale(0.98); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes pop-out {
+  from { opacity: 1; transform: scale(1); }
+  to { opacity: 0; transform: scale(0.98); }
+}
+
+/* Dialogs are centered with the CSS `translate` property so scale animations
+   don't fight the centering transform. */
+@keyframes dialog-in {
+  from { opacity: 0; transform: scale(0.98); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes dialog-out {
+  from { opacity: 1; transform: scale(1); }
+  to { opacity: 0; transform: scale(0.98); }
 }
 
 @keyframes slide-up {
-  from { opacity: 0; transform: translateY(8px); }
+  from { opacity: 0; transform: translateY(6px); }
   to { opacity: 1; transform: translateY(0); }
 }
 
 @keyframes slide-in-right {
-  from { opacity: 0; transform: translateX(16px); }
+  from { opacity: 0; transform: translateX(8px); }
   to { opacity: 1; transform: translateX(0); }
 }
 
 @keyframes slide-in-down {
-  from { opacity: 0; transform: translateY(-8px); }
+  from { opacity: 0; transform: translateY(-6px); }
   to { opacity: 1; transform: translateY(0); }
 }
 
@@ -338,16 +365,16 @@
 }
 
 @layer utilities {
-  .animate-fade-in { animation: fade-in 140ms ease-out both; }
-  .animate-pop-in { animation: pop-in 160ms var(--ease-out-quint) both; }
-  .animate-slide-up { animation: slide-up 180ms var(--ease-out-quint) both; }
-  .animate-slide-in-right { animation: slide-in-right 180ms var(--ease-out-quint) both; }
-  .animate-slide-in-down { animation: slide-in-down 160ms var(--ease-out-quint) both; }
+  .animate-fade-in { animation: fade-in var(--motion-fast) ease-out both; }
+  .animate-pop-in { animation: pop-in var(--motion) var(--ease-out-quint) both; }
+  .animate-slide-up { animation: slide-up var(--motion) var(--ease-out-quint) both; }
+  .animate-slide-in-right { animation: slide-in-right var(--motion) var(--ease-out-quint) both; }
+  .animate-slide-in-down { animation: slide-in-down var(--motion) var(--ease-out-quint) both; }
   .animate-pulse-ring { animation: pulse-ring 1.8s ease-out infinite; }
   .animate-spin-slow { animation: spin 900ms linear infinite; }
 
   .hover-lift {
-    transition: transform 140ms var(--ease-out-quint), box-shadow 140ms var(--ease-out-quint);
+    transition: transform var(--motion-fast) var(--ease-out-quint), box-shadow var(--motion-fast) var(--ease-out-quint);
   }
   .hover-lift:hover {
     transform: translateY(-1px);
@@ -358,6 +385,34 @@
     background-size: 400% 100%;
     animation: shimmer 1.4s ease-in-out infinite;
   }
+}
+
+/* Radix surfaces: enter AND exit. Presence waits for the closed animation. */
+.ui-overlay[data-state="open"] {
+  animation: fade-in var(--motion-fast) ease-out both;
+}
+.ui-overlay[data-state="closed"] {
+  animation: fade-out var(--motion-fast) var(--motion-in) both;
+}
+
+.ui-pop {
+  transform-origin: var(--radix-dropdown-menu-content-transform-origin, center top);
+}
+.ui-pop[data-state="open"] {
+  animation: pop-in var(--motion) var(--motion-out) both;
+}
+.ui-pop[data-state="closed"] {
+  animation: pop-out var(--motion-fast) var(--motion-in) both;
+}
+
+.ui-dialog {
+  translate: -50% -50%;
+}
+.ui-dialog[data-state="open"] {
+  animation: dialog-in var(--motion) var(--motion-out) both;
+}
+.ui-dialog[data-state="closed"] {
+  animation: dialog-out var(--motion-fast) var(--motion-in) both;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/desktop/src/lib/motion.ts
+++ b/desktop/src/lib/motion.ts
@@ -1,0 +1,14 @@
+/** Shared timing for chrome motion. Keep these short — premium, not theatrical. */
+export const EASE_OUT = [0.22, 1, 0.36, 1] as const;
+
+export const duration = {
+  fast: 0.12,
+  base: 0.16,
+  layout: 0.2,
+} as const;
+
+export const snappy = { duration: duration.base, ease: EASE_OUT };
+export const layoutTween = { duration: duration.layout, ease: EASE_OUT };
+
+/** Matches `Sidebar` inner width so the rail can clip instead of squash. */
+export const SIDEBAR_WIDTH = 208;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Primitive-level motion

Short, quiet animations so chrome and menus feel finished instead of snapping.

## What changed

**Primitives**
- Dialogs, dropdowns, selects, and tooltips now animate **open and close** (`data-state`)
- Buttons press in slightly (`scale 0.98`)
- Switch thumb uses a 150ms ease

**Chrome**
- Sidebar **clips** open/closed on width (200ms) instead of popping in
- Pages crossfade in place (fixes previous motion being clipped by `overflow: hidden`)
- Transcript panel, note tabs, settings tabs, and onboarding steps fade/slide a few pixels
- Chat session list and the back button expand/collapse with height

Timing stays in the 120–200ms range. `prefers-reduced-motion` is respected.

## Verify

```bash
cd desktop && npm run build
```

Toggle the sidebar (`Ctrl+\`), open a menu, and open/close the transcript panel.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

