### PR TITLE
Slide the sidebar closed instead of clipping it away

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -19,7 +19,7 @@ import { ChatPage } from "@/components/pages/ChatPage";
 import { SpacePage } from "@/components/pages/SpacePage";
 import { SharedPage } from "@/components/pages/SharedPage";
 import { SettingsPage } from "@/components/pages/SettingsPage";
-import { layoutTween, SIDEBAR_WIDTH, snappy } from "@/lib/motion";
+import { sidebarTween, SIDEBAR_WIDTH, snappy } from "@/lib/motion";
 
 export default function App() {
   const route = useAppStore((s) => s.route);
@@ -41,12 +41,19 @@ export default function App() {
                 initial={{ width: 0 }}
                 animate={{ width: SIDEBAR_WIDTH }}
                 exit={{ width: 0 }}
-                transition={layoutTween}
+                transition={sidebarTween}
                 className="relative h-full shrink-0 overflow-hidden"
               >
-                <div className="absolute inset-y-0 left-0 h-full" style={{ width: SIDEBAR_WIDTH }}>
+                <motion.div
+                  initial={{ x: -SIDEBAR_WIDTH }}
+                  animate={{ x: 0 }}
+                  exit={{ x: -SIDEBAR_WIDTH }}
+                  transition={sidebarTween}
+                  className="absolute inset-y-0 left-0 h-full"
+                  style={{ width: SIDEBAR_WIDTH }}
+                >
                   <Sidebar />
-                </div>
+                </motion.div>
               </motion.div>
             )}
           </AnimatePresence>

--- a/desktop/src/lib/motion.ts
+++ b/desktop/src/lib/motion.ts
@@ -1,14 +1,18 @@
 /** Shared timing for chrome motion. Keep these short — premium, not theatrical. */
 export const EASE_OUT = [0.22, 1, 0.36, 1] as const;
+/** Even travel so a short slide is visible instead of snapping away. */
+export const EASE_SLIDE = [0.4, 0, 0.2, 1] as const;
 
 export const duration = {
   fast: 0.12,
   base: 0.16,
   layout: 0.2,
+  sidebar: 0.18,
 } as const;
 
 export const snappy = { duration: duration.base, ease: EASE_OUT };
 export const layoutTween = { duration: duration.layout, ease: EASE_OUT };
+export const sidebarTween = { duration: duration.sidebar, ease: EASE_SLIDE };
 
 /** Matches `Sidebar` inner width so the rail can clip instead of squash. */
 export const SIDEBAR_WIDTH = 208;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Sidebar slide

Closing the sidebar was clipping the rail to zero width, so it looked like it vanished. It now slides left while the slot collapses.

Still **180ms** — short enough that it doesn’t lag, long enough that you can see the slide. Same curve on open and close.

Toggle with `Ctrl+\`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

