### PR TITLE
Add Granola-style Create folder panel

### DIFF
--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -25,6 +25,8 @@ pub struct Folder {
     pub parent_id: Option<String>,
     pub name: String,
     pub is_shared: bool,
+    pub icon: Option<String>,
+    pub description: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -139,7 +141,7 @@ pub fn db_status(app: AppHandle, state: State<AppState>) -> Result<DbStatus, Str
 pub fn list_folders(state: State<AppState>) -> Result<Vec<Folder>, String> {
     let conn = state.conn()?;
     let mut stmt = conn
-        .prepare("SELECT id, parent_id, name, is_shared FROM folders ORDER BY name")
+        .prepare("SELECT id, parent_id, name, is_shared, icon, description FROM folders ORDER BY name")
         .map_err(|e| e.to_string())?;
     let rows = stmt
         .query_map([], |row| {
@@ -148,6 +150,8 @@ pub fn list_folders(state: State<AppState>) -> Result<Vec<Folder>, String> {
                 parent_id: row.get(1)?,
                 name: row.get(2)?,
                 is_shared: row.get::<_, i64>(3)? != 0,
+                icon: row.get(4)?,
+                description: row.get(5)?,
             })
         })
         .map_err(|e| e.to_string())?;
@@ -888,17 +892,35 @@ pub fn create_folder(
     state: State<AppState>,
     name: String,
     is_shared: Option<bool>,
+    icon: Option<String>,
+    description: Option<String>,
 ) -> Result<Folder, String> {
     let name = name.trim().to_string();
     if name.is_empty() {
         return Err("Folder name can't be empty".into());
     }
+    let icon = icon.and_then(|s| {
+        let trimmed = s.trim().to_string();
+        if trimmed.is_empty() || trimmed == "folder" {
+            None
+        } else {
+            Some(trimmed)
+        }
+    });
+    let description = description.and_then(|s| {
+        let trimmed = s.trim().to_string();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    });
     let conn = state.conn()?;
     let id = new_id("folder");
     let shared = is_shared.unwrap_or(false);
     conn.execute(
-        "INSERT INTO folders (id, name, is_shared) VALUES (?1,?2,?3)",
-        params![id, name, if shared { 1 } else { 0 }],
+        "INSERT INTO folders (id, name, is_shared, icon, description) VALUES (?1,?2,?3,?4,?5)",
+        params![id, name, if shared { 1 } else { 0 }, icon, description],
     )
     .map_err(|e| e.to_string())?;
     Ok(Folder {
@@ -906,6 +928,8 @@ pub fn create_folder(
         parent_id: None,
         name,
         is_shared: shared,
+        icon,
+        description,
     })
 }
 

--- a/desktop/src-tauri/src/db/migrations.rs
+++ b/desktop/src-tauri/src/db/migrations.rs
@@ -301,6 +301,12 @@ INSERT INTO meetings_fts(rowid, title, scratchpad_raw, enhanced_notes_json)
 SELECT rowid, title, scratchpad_raw, ifnull(enhanced_notes_json, '') FROM meetings;
 "#;
 
+/// Folder create panel: optional icon (template id) and purpose description.
+const V5: &str = r#"
+ALTER TABLE folders ADD COLUMN icon TEXT;
+ALTER TABLE folders ADD COLUMN description TEXT;
+"#;
+
 pub fn apply(conn: &Connection, vec_enabled: bool) -> Result<(), String> {
     let current: i64 = conn
         .query_row(
@@ -357,6 +363,16 @@ pub fn apply(conn: &Connection, vec_enabled: bool) -> Result<(), String> {
             [],
         )
         .map_err(|e| format!("record v4: {e}"))?;
+    }
+
+    if current < 5 {
+        conn.execute_batch(V5)
+            .map_err(|e| format!("migration v5: {e}"))?;
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version) VALUES (5)",
+            [],
+        )
+        .map_err(|e| format!("record v5: {e}"))?;
     }
 
     if vec_enabled {

--- a/desktop/src-tauri/src/http.rs
+++ b/desktop/src-tauri/src/http.rs
@@ -252,7 +252,7 @@ fn get_note(conn: &Connection, id: &str) -> Option<serde_json::Value> {
 fn list_folders(conn: &Connection) -> serde_json::Value {
     query_json(
         conn,
-        "SELECT id, name, parent_id, is_shared FROM folders ORDER BY name",
+        "SELECT id, name, parent_id, is_shared, icon, description FROM folders ORDER BY name",
         [],
         |row| {
             Ok(json!({
@@ -260,6 +260,8 @@ fn list_folders(conn: &Connection) -> serde_json::Value {
                 "name": row.get::<_, String>(1)?,
                 "parent_id": row.get::<_, Option<String>>(2)?,
                 "is_shared": row.get::<_, i64>(3)? != 0,
+                "icon": row.get::<_, Option<String>>(4)?,
+                "description": row.get::<_, Option<String>>(5)?,
             }))
         },
     )

--- a/desktop/src/components/layout/CreateFolderDialog.test.tsx
+++ b/desktop/src/components/layout/CreateFolderDialog.test.tsx
@@ -1,0 +1,50 @@
+/// <reference types="vitest/globals" />
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { CreateFolderDialog } from "./CreateFolderDialog";
+import { FOLDER_TEMPLATES } from "@/lib/folder-templates";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    createFolder: vi.fn(),
+  };
+});
+
+function renderDialog(initialShared = false) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const onOpenChange = vi.fn();
+  render(
+    <QueryClientProvider client={client}>
+      <CreateFolderDialog open initialShared={initialShared} workspaceName="Dheeraj" onOpenChange={onOpenChange} />
+    </QueryClientProvider>,
+  );
+  return { onOpenChange };
+}
+
+describe("CreateFolderDialog", () => {
+  it("keeps Create disabled until a name is entered", () => {
+    renderDialog();
+    expect(screen.getByRole("heading", { name: "Create folder" })).toBeInTheDocument();
+    const create = screen.getByRole("button", { name: "Create" });
+    expect(create).toBeDisabled();
+    fireEvent.change(screen.getByPlaceholderText("Name"), { target: { value: "Sales" } });
+    expect(create).toBeEnabled();
+  });
+
+  it("fills name and description from a template chip", () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: "Projects" }));
+    const projects = FOLDER_TEMPLATES.find((t) => t.id === "projects")!;
+    expect(screen.getByPlaceholderText("Name")).toHaveValue(projects.name);
+    expect(screen.getByPlaceholderText("Describe the purpose of this folder")).toHaveValue(projects.description);
+    expect(screen.getByRole("button", { name: "Create" })).toBeEnabled();
+  });
+
+  it("defaults the space to the team when opened from a shared Add folder", () => {
+    renderDialog(true);
+    expect(screen.getByText("Everyone in your workspace will be able to view this folder.")).toBeInTheDocument();
+    expect(screen.getByText("Dheeraj team")).toBeInTheDocument();
+  });
+});

--- a/desktop/src/components/layout/CreateFolderDialog.tsx
+++ b/desktop/src/components/layout/CreateFolderDialog.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Lock } from "lucide-react";
+import * as api from "@/lib/api";
+import { FOLDER_TEMPLATES, folderGlyph, folderGlyphClass, type FolderTemplateId } from "@/lib/folder-templates";
+import { cn } from "@/lib/utils";
+import { useAppStore } from "@/store/app";
+import { Avatar } from "@/components/ui/misc";
+import { toast } from "@/components/ui/toast";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/controls";
+
+type SpaceId = "private" | "team";
+
+export function CreateFolderDialog({
+  open,
+  initialShared,
+  workspaceName,
+  onOpenChange,
+}: {
+  open: boolean;
+  initialShared: boolean;
+  workspaceName: string;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [icon, setIcon] = useState<string>("folder");
+  const [templateId, setTemplateId] = useState<FolderTemplateId | null>(null);
+  const [space, setSpace] = useState<SpaceId>(initialShared ? "team" : "private");
+
+  const queryClient = useQueryClient();
+  const navigate = useAppStore((s) => s.navigate);
+  const teamLabel = `${workspaceName} team`;
+  const shared = space === "team";
+  const canCreate = name.trim().length > 0;
+  const NameIcon = folderGlyph(icon);
+
+  useEffect(() => {
+    if (!open) return;
+    setName("");
+    setDescription("");
+    setIcon("folder");
+    setTemplateId(null);
+    setSpace(initialShared ? "team" : "private");
+  }, [open, initialShared]);
+
+  const create = useMutation({
+    mutationFn: () =>
+      api.createFolder(name.trim(), shared, {
+        icon: icon === "folder" ? null : icon,
+        description: description.trim() || null,
+      }),
+    onSuccess: (folder) => {
+      void queryClient.invalidateQueries({ queryKey: api.qk.folders() });
+      onOpenChange(false);
+      navigate({ kind: "space", spaceId: folder.id });
+    },
+    onError: (e) => toast.error(e),
+  });
+
+  function applyTemplate(id: FolderTemplateId) {
+    const template = FOLDER_TEMPLATES.find((t) => t.id === id);
+    if (!template) return;
+    setTemplateId(id);
+    setIcon(id);
+    setName(template.name);
+    setDescription(template.description);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[440px] p-6">
+        <DialogHeader className="mb-5">
+          <DialogTitle className="text-[17px]">Create folder</DialogTitle>
+          <DialogDescription className="sr-only">
+            Name this folder, optionally start from a template, and choose which space it lives in.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (canCreate && !create.isPending) create.mutate();
+          }}
+        >
+          <label className="mb-1.5 block text-[13px] text-muted" htmlFor="create-folder-name">
+            Name and icon
+          </label>
+          <div
+            className={cn(
+              "flex h-10 items-center gap-2 rounded-xl border border-border bg-surface px-3",
+              "transition-[border-color,box-shadow] duration-150",
+              "hover:border-border-strong focus-within:border-accent focus-within:ring-2 focus-within:ring-accent/25",
+            )}
+          >
+            <NameIcon className={cn("size-4 shrink-0", folderGlyphClass(icon))} aria-hidden />
+            <input
+              id="create-folder-name"
+              autoFocus
+              autoComplete="off"
+              placeholder="Name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="h-full min-w-0 flex-1 bg-transparent text-[13px] text-text outline-none placeholder:text-subtle"
+            />
+          </div>
+
+          <p className="mb-2 mt-4 text-[12px] text-subtle">Or start from a template</p>
+          <div className="flex flex-wrap gap-2">
+            {FOLDER_TEMPLATES.map((template) => {
+              const Icon = folderGlyph(template.id);
+              const selected = templateId === template.id;
+              return (
+                <button
+                  key={template.id}
+                  type="button"
+                  onClick={() => applyTemplate(template.id)}
+                  className={cn(
+                    "inline-flex h-8 items-center gap-1.5 rounded-full border px-3 text-[13px] transition-[background-color,border-color,transform,color] duration-150 ease-out",
+                    "hover:scale-[1.02] hover:bg-hover active:scale-[0.98]",
+                    selected
+                      ? "border-border-strong bg-hover text-text"
+                      : "border-border bg-transparent text-muted hover:text-text",
+                  )}
+                >
+                  <Icon className={cn("size-3.5", folderGlyphClass(template.id))} />
+                  {template.name}
+                </button>
+              );
+            })}
+          </div>
+
+          <label className="mb-1.5 mt-5 block text-[13px] text-muted" htmlFor="create-folder-description">
+            Description
+          </label>
+          <Textarea
+            id="create-folder-description"
+            rows={3}
+            placeholder="Describe the purpose of this folder"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            className="min-h-[88px] rounded-xl"
+          />
+
+          <label className="mb-1.5 mt-5 block text-[13px] text-muted" htmlFor="create-folder-space">
+            Space
+          </label>
+          <Select value={space} onValueChange={(value) => setSpace(value as SpaceId)}>
+            <SelectTrigger id="create-folder-space" className="h-10 w-full rounded-xl px-3">
+              <span className="flex min-w-0 items-center gap-2">
+                {shared ? (
+                  <Avatar name={workspaceName} size={18} className="rounded-full" />
+                ) : (
+                  <Lock className="size-3.5 text-muted" />
+                )}
+                <span className="truncate">{shared ? teamLabel : "My notes"}</span>
+              </span>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="private">
+                <span className="flex items-center gap-2">
+                  <Lock className="size-3.5 text-muted" />
+                  My notes
+                </span>
+              </SelectItem>
+              <SelectItem value="team">
+                <span className="flex items-center gap-2">
+                  <Avatar name={workspaceName} size={18} className="rounded-full" />
+                  {teamLabel}
+                </span>
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="mt-1.5 text-[12px] leading-snug text-subtle">
+            {shared ? "Everyone in your workspace will be able to view this folder." : "Only you can see this folder."}
+          </p>
+
+          <DialogFooter className="mt-6">
+            <Button type="button" variant="subtle" size="md" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="solid" size="md" disabled={!canCreate} loading={create.isPending}>
+              Create
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/desktop/src/components/layout/Sidebar.tsx
+++ b/desktop/src/components/layout/Sidebar.tsx
@@ -34,9 +34,10 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { CreateFolderDialog } from "@/components/layout/CreateFolderDialog";
+import { folderGlyph, folderGlyphClass } from "@/lib/folder-templates";
 import { SIDEBAR_WIDTH, layoutTween } from "@/lib/motion";
 import { AnimatePresence, motion } from "framer-motion";
 
@@ -63,10 +64,7 @@ export function Sidebar() {
   const sharedFolders = folders.filter((f) => f.is_shared);
 
   return (
-    <aside
-      className="flex h-full shrink-0 flex-col border-r border-border bg-sidebar"
-      style={{ width: SIDEBAR_WIDTH }}
-    >
+    <aside className="flex h-full shrink-0 flex-col border-r border-border bg-sidebar" style={{ width: SIDEBAR_WIDTH }}>
       {/* Brand row doubles as the drag handle for the sidebar column. */}
       <div data-tauri-drag-region className="flex h-11 items-center px-3">
         <button
@@ -90,12 +88,7 @@ export function Sidebar() {
           <Kbd>Ctrl+K</Kbd>
         </button>
 
-        <NavItem
-          icon={Home}
-          label="Home"
-          active={route.kind === "home"}
-          onClick={() => navigate({ kind: "home" })}
-        />
+        <NavItem icon={Home} label="Home" active={route.kind === "home"} onClick={() => navigate({ kind: "home" })} />
         <NavItem
           icon={Users}
           label="Shared with me"
@@ -110,11 +103,7 @@ export function Sidebar() {
           expanded={sessions.length > 0 ? chatExpanded : undefined}
           onToggleExpanded={() => setChatExpanded((v) => !v)}
           trailing={
-            <IconAction
-              label="New chat"
-              icon={Plus}
-              onClick={() => navigate({ kind: "chat", sessionId: null })}
-            />
+            <IconAction label="New chat" icon={Plus} onClick={() => navigate({ kind: "chat", sessionId: null })} />
           }
         />
 
@@ -141,9 +130,7 @@ export function Sidebar() {
                     )}
                   >
                     <span className="min-w-0 flex-1 truncate">{session.title || "New chat"}</span>
-                    <span className="shrink-0 text-[11px] text-subtle">
-                      {formatRelative(session.updated_at)}
-                    </span>
+                    <span className="shrink-0 text-[11px] text-subtle">{formatRelative(session.updated_at)}</span>
                   </button>
                 ))}
               </div>
@@ -164,6 +151,7 @@ export function Sidebar() {
             key={folder.id}
             id={folder.id}
             name={folder.name}
+            icon={folder.icon}
             active={route.kind === "space" && route.spaceId === folder.id}
             onClick={() => navigate({ kind: "space", spaceId: folder.id })}
           />
@@ -181,6 +169,7 @@ export function Sidebar() {
             key={folder.id}
             id={folder.id}
             name={folder.name}
+            icon={folder.icon}
             active={route.kind === "space" && route.spaceId === folder.id}
             onClick={() => navigate({ kind: "space", spaceId: folder.id })}
           />
@@ -196,9 +185,10 @@ export function Sidebar() {
         navigate={navigate}
       />
 
-      <NewFolderDialog
+      <CreateFolderDialog
         open={newFolderIn !== null}
-        shared={newFolderIn?.shared ?? false}
+        initialShared={newFolderIn?.shared ?? false}
+        workspaceName={workspaceName}
         onOpenChange={(open) => !open && setNewFolderIn(null)}
       />
     </aside>
@@ -267,14 +257,17 @@ function NavItem({
 function FolderItem({
   id,
   name,
+  icon,
   active,
   onClick,
 }: {
   id: string;
   name: string;
+  icon: string | null;
   active: boolean;
   onClick: () => void;
 }) {
+  const Glyph = folderGlyph(icon);
   const queryClient = useQueryClient();
   const [renaming, setRenaming] = useState(false);
   const [draft, setDraft] = useState(name);
@@ -333,11 +326,12 @@ function FolderItem({
         type="button"
         onClick={onClick}
         className={cn(
-          "min-w-0 flex-1 truncate py-1 text-left text-[13px]",
+          "flex min-w-0 flex-1 items-center gap-1.5 truncate py-1 text-left text-[13px]",
           active ? "font-medium text-text" : "text-muted group-hover:text-text",
         )}
       >
-        {name}
+        {icon ? <Glyph className={cn("size-3.5 shrink-0", folderGlyphClass(icon))} /> : null}
+        <span className="truncate">{name}</span>
       </button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
@@ -381,15 +375,7 @@ function AddFolderButton({ onClick }: { onClick: () => void }) {
   );
 }
 
-function IconAction({
-  label,
-  icon: Icon,
-  onClick,
-}: {
-  label: string;
-  icon: LucideIcon;
-  onClick: () => void;
-}) {
+function IconAction({ label, icon: Icon, onClick }: { label: string; icon: LucideIcon; onClick: () => void }) {
   return (
     <Tooltip label={label}>
       <button
@@ -490,15 +476,7 @@ function SidebarFooter({
   );
 }
 
-function FooterIcon({
-  label,
-  icon: Icon,
-  onClick,
-}: {
-  label: string;
-  icon: LucideIcon;
-  onClick: () => void;
-}) {
+function FooterIcon({ label, icon: Icon, onClick }: { label: string; icon: LucideIcon; onClick: () => void }) {
   return (
     <Tooltip label={label} side="top">
       <button
@@ -510,69 +488,5 @@ function FooterIcon({
         <Icon className="size-3.5" />
       </button>
     </Tooltip>
-  );
-}
-
-/* ------------------------------------------------------------------ */
-
-function NewFolderDialog({
-  open,
-  shared,
-  onOpenChange,
-}: {
-  open: boolean;
-  shared: boolean;
-  onOpenChange: (open: boolean) => void;
-}) {
-  const [name, setName] = useState("");
-  const queryClient = useQueryClient();
-  const navigate = useAppStore((s) => s.navigate);
-
-  const create = useMutation({
-    mutationFn: () => api.createFolder(name.trim(), shared),
-    onSuccess: (folder) => {
-      void queryClient.invalidateQueries({ queryKey: api.qk.folders() });
-      onOpenChange(false);
-      setName("");
-      navigate({ kind: "space", spaceId: folder.id });
-    },
-    onError: (e) => toast.error(e),
-  });
-
-  return (
-    <Dialog
-      open={open}
-      onOpenChange={(next) => {
-        if (!next) setName("");
-        onOpenChange(next);
-      }}
-    >
-      <DialogContent className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle>New folder</DialogTitle>
-        </DialogHeader>
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            if (name.trim()) create.mutate();
-          }}
-        >
-          <Input
-            autoFocus
-            placeholder={shared ? "Team folder name" : "Folder name"}
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-          />
-          <DialogFooter>
-            <Button type="button" variant="ghost" size="md" onClick={() => onOpenChange(false)}>
-              Cancel
-            </Button>
-            <Button type="submit" variant="solid" size="md" disabled={!name.trim()} loading={create.isPending}>
-              Create
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
   );
 }

--- a/desktop/src/components/pages/SettingsPage.tsx
+++ b/desktop/src/components/pages/SettingsPage.tsx
@@ -679,7 +679,9 @@ function SpacesTab() {
           <SettingRow
             key={folder.id}
             title={folder.name}
-            description={folder.is_shared ? "Shared with the workspace" : "Private"}
+            description={
+              folder.description || (folder.is_shared ? "Shared with the workspace" : "Private")
+            }
             control={folder.is_shared ? <Badge tone="accent">Shared</Badge> : <Badge>Private</Badge>}
           />
         ))}

--- a/desktop/src/components/pages/SpacePage.tsx
+++ b/desktop/src/components/pages/SpacePage.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Blocks, Folder as FolderIcon, Lock, NotebookPen, Users, X } from "lucide-react";
+import { Blocks, Lock, NotebookPen, Users, X } from "lucide-react";
 import * as api from "@/lib/api";
 import { MY_NOTES_SPACE, TEAM_SPACE } from "@/lib/types";
+import { folderGlyph, folderGlyphClass } from "@/lib/folder-templates";
 import { useAppStore } from "@/store/app";
 import { useChat } from "@/hooks/useChat";
 import { spaceToFolderId, useCreateNote } from "@/hooks/useCreateNote";
@@ -10,6 +11,7 @@ import { NoteList } from "@/components/notes/NoteList";
 import { AskBar, RecipeChips } from "@/components/chat/AskBar";
 import { Avatar, EmptyState } from "@/components/ui/misc";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 const BANNER_DISMISS_PREFIX = "bagrry.banner.";
 
@@ -39,6 +41,8 @@ export function SpacePage({ spaceId }: { spaceId: string }) {
       : spaceId === TEAM_SPACE
         ? allNotes.filter((n) => n.folder_id && sharedFolderIds.has(n.folder_id))
         : allNotes;
+
+  const FolderGlyph = folderGlyph(folder?.icon);
 
   const header =
     spaceId === MY_NOTES_SPACE
@@ -81,11 +85,11 @@ export function SpacePage({ spaceId }: { spaceId: string }) {
             },
           }
         : {
-            icon: <FolderIcon className="size-3.5" />,
+            icon: <FolderGlyph className={cn("size-3.5", folderGlyphClass(folder?.icon))} />,
             title: folder?.name ?? "Folder",
-            subtitle: folder?.is_shared
-              ? "Shared with your workspace."
-              : "A private folder in your space.",
+            subtitle:
+              folder?.description ||
+              (folder?.is_shared ? "Shared with your workspace." : "A private folder in your space."),
             meta: folder?.is_shared ? (
               <>
                 <Users className="size-3" />

--- a/desktop/src/lib/api.ts
+++ b/desktop/src/lib/api.ts
@@ -36,8 +36,17 @@ export const moveMeeting = (id: string, folderId?: string | null) =>
 export const duplicateMeeting = (id: string) => invoke<Meeting>("duplicate_meeting", { id });
 
 export const listFolders = () => invoke<Folder[]>("list_folders");
-export const createFolder = (name: string, isShared = false) =>
-  invoke<Folder>("create_folder", { name, isShared });
+export const createFolder = (
+  name: string,
+  isShared = false,
+  extras?: { icon?: string | null; description?: string | null },
+) =>
+  invoke<Folder>("create_folder", {
+    name,
+    isShared,
+    icon: extras?.icon ?? null,
+    description: extras?.description ?? null,
+  });
 export const renameFolder = (id: string, name: string) => invoke<void>("rename_folder", { id, name });
 export const deleteFolder = (id: string) => invoke<void>("delete_folder", { id });
 export const setFolderShared = (id: string, isShared: boolean) =>

--- a/desktop/src/lib/folder-templates.ts
+++ b/desktop/src/lib/folder-templates.ts
@@ -1,0 +1,63 @@
+import { CalendarDays, Folder, Presentation, Tag, Users, type LucideIcon } from "lucide-react";
+
+/** Starter kits for the Create folder panel. Ids are stored on the folder row. */
+export type FolderTemplateId = "projects" | "meetings" | "coaching" | "standups";
+
+export type FolderTemplate = {
+  id: FolderTemplateId;
+  name: string;
+  description: string;
+};
+
+export const FOLDER_TEMPLATES: FolderTemplate[] = [
+  {
+    id: "projects",
+    name: "Projects",
+    description: "Specs, workstreams, and project meetings in one place.",
+  },
+  {
+    id: "meetings",
+    name: "Team meetings",
+    description: "Recurring team meetings, agendas, and follow-ups.",
+  },
+  {
+    id: "coaching",
+    name: "Coaching",
+    description: "1-on-1s, career conversations, and coaching notes.",
+  },
+  {
+    id: "standups",
+    name: "Standups",
+    description: "Daily standups, blockers, and team updates.",
+  },
+];
+
+export function folderGlyph(icon: string | null | undefined): LucideIcon {
+  switch (icon) {
+    case "projects":
+      return Presentation;
+    case "meetings":
+      return CalendarDays;
+    case "coaching":
+      return Tag;
+    case "standups":
+      return Users;
+    default:
+      return Folder;
+  }
+}
+
+export function folderGlyphClass(icon: string | null | undefined): string {
+  switch (icon) {
+    case "projects":
+      return "text-[#b794f6]";
+    case "meetings":
+      return "text-[#4ade80]";
+    case "coaching":
+      return "text-[#f6c945]";
+    case "standups":
+      return "text-text";
+    default:
+      return "text-muted";
+  }
+}

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -14,6 +14,8 @@ export type Folder = {
   parent_id: string | null;
   name: string;
   is_shared: boolean;
+  icon: string | null;
+  description: string | null;
 };
 
 export type Meeting = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replaces the thin “New folder” name dialog with a Create folder panel matching the reference UI.

**Panel**
- Title **Create folder** with close
- **Name and icon** field (folder/template glyph + name, accent focus ring)
- **Or start from a template** chips: Projects, Team meetings, Coaching, Standups — clicking one fills name, description, and icon
- **Description** textarea
- **Space** picker (My notes vs `{workspace} team`) with a caption about who can see the folder
- **Cancel** / **Create** (Create stays disabled until a name is entered)
- Existing dialog enter/exit motion

**Persistence**
- SQLite v5 adds optional `icon` and `description` on `folders`
- Space maps to `is_shared`; template chips persist their icon id

Opened from either **Add folder** control in the sidebar; the space defaults to private or team based on which one was clicked.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

