### PR TITLE
Add People and Companies directory panels

### DIFF
--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -65,6 +65,8 @@ pub struct Person {
     pub email: Option<String>,
     pub domain: Option<String>,
     pub company_id: Option<String>,
+    pub note_count: i64,
+    pub last_note_at: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -72,6 +74,8 @@ pub struct Company {
     pub id: String,
     pub name: String,
     pub domain: Option<String>,
+    pub note_count: i64,
+    pub last_note_at: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -597,7 +601,15 @@ pub fn search_meetings(state: State<AppState>, query: String) -> Result<Vec<Meet
 pub fn list_people(state: State<AppState>) -> Result<Vec<Person>, String> {
     let conn = state.conn()?;
     let mut stmt = conn
-        .prepare("SELECT id, name, email, domain, company_id FROM attendees ORDER BY name")
+        .prepare(
+            "SELECT a.id, a.name, a.email, a.domain, a.company_id,
+                    COUNT(m.id), MAX(m.date)
+             FROM attendees a
+             LEFT JOIN meeting_attendees ma ON ma.attendee_id = a.id
+             LEFT JOIN meetings m ON m.id = ma.meeting_id
+             GROUP BY a.id
+             ORDER BY (MAX(m.date) IS NULL), MAX(m.date) DESC, a.name",
+        )
         .map_err(|e| e.to_string())?;
     let rows = stmt
         .query_map([], |row| {
@@ -607,6 +619,8 @@ pub fn list_people(state: State<AppState>) -> Result<Vec<Person>, String> {
                 email: row.get(2)?,
                 domain: row.get(3)?,
                 company_id: row.get(4)?,
+                note_count: row.get(5)?,
+                last_note_at: row.get(6)?,
             })
         })
         .map_err(|e| e.to_string())?;
@@ -618,7 +632,17 @@ pub fn list_people(state: State<AppState>) -> Result<Vec<Person>, String> {
 pub fn list_companies(state: State<AppState>) -> Result<Vec<Company>, String> {
     let conn = state.conn()?;
     let mut stmt = conn
-        .prepare("SELECT id, name, domain FROM companies ORDER BY name")
+        .prepare(
+            "SELECT c.id, c.name, c.domain,
+                    COUNT(DISTINCT m.id), MAX(m.date)
+             FROM companies c
+             LEFT JOIN attendees a
+               ON a.company_id = c.id OR (c.domain IS NOT NULL AND a.domain = c.domain)
+             LEFT JOIN meeting_attendees ma ON ma.attendee_id = a.id
+             LEFT JOIN meetings m ON m.id = ma.meeting_id
+             GROUP BY c.id
+             ORDER BY (MAX(m.date) IS NULL), MAX(m.date) DESC, c.name",
+        )
         .map_err(|e| e.to_string())?;
     let rows = stmt
         .query_map([], |row| {
@@ -626,6 +650,8 @@ pub fn list_companies(state: State<AppState>) -> Result<Vec<Company>, String> {
                 id: row.get(0)?,
                 name: row.get(1)?,
                 domain: row.get(2)?,
+                note_count: row.get(3)?,
+                last_note_at: row.get(4)?,
             })
         })
         .map_err(|e| e.to_string())?;
@@ -684,6 +710,8 @@ pub fn upsert_person(
         email,
         domain,
         company_id: None,
+        note_count: 0,
+        last_note_at: None,
     })
 }
 
@@ -1275,6 +1303,8 @@ pub fn list_meeting_attendees(
                 email: row.get(2)?,
                 domain: row.get(3)?,
                 company_id: row.get(4)?,
+                note_count: 0,
+                last_note_at: None,
             })
         })
         .map_err(|e| e.to_string())?;

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -18,6 +18,8 @@ import { NotePage } from "@/components/pages/NotePage";
 import { ChatPage } from "@/components/pages/ChatPage";
 import { SpacePage } from "@/components/pages/SpacePage";
 import { SharedPage } from "@/components/pages/SharedPage";
+import { PeoplePage } from "@/components/pages/PeoplePage";
+import { CompaniesPage } from "@/components/pages/CompaniesPage";
 import { SettingsPage } from "@/components/pages/SettingsPage";
 import { layoutTween, SIDEBAR_WIDTH, snappy } from "@/lib/motion";
 
@@ -68,6 +70,8 @@ export default function App() {
                   {route.kind === "space" && <SpacePage spaceId={route.spaceId} />}
                   {route.kind === "note" && <NotePage noteId={route.noteId} />}
                   {route.kind === "chat" && <ChatPage sessionId={route.sessionId} />}
+                  {route.kind === "people" && <PeoplePage />}
+                  {route.kind === "companies" && <CompaniesPage />}
                   {route.kind === "settings" && <SettingsPage tab={route.tab} />}
                 </motion.div>
               </AnimatePresence>
@@ -93,7 +97,10 @@ function useRecordingBridge() {
     let disposed = false;
     const unlisteners: Array<() => void> = [];
 
-    api.recordingStatus().then(applyRecStatus).catch(() => undefined);
+    api
+      .recordingStatus()
+      .then(applyRecStatus)
+      .catch(() => undefined);
 
     const register = <T,>(event: string, handler: (payload: T) => void) => {
       listen<T>(event, (e) => handler(e.payload))

--- a/desktop/src/components/CommandPalette.tsx
+++ b/desktop/src/components/CommandPalette.tsx
@@ -1,16 +1,7 @@
 import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Command } from "cmdk";
-import {
-  FileText,
-  Home,
-  MessageSquare,
-  Mic,
-  Plus,
-  Search,
-  Settings,
-  Users,
-} from "lucide-react";
+import { Building2, FileText, Home, MessageSquare, Mic, Plus, Search, Settings, User, Users } from "lucide-react";
 import * as api from "@/lib/api";
 import { formatDayLabel } from "@/lib/format";
 import { MY_NOTES_SPACE } from "@/lib/types";
@@ -129,6 +120,14 @@ export function CommandPalette() {
               <Item onSelect={() => run(() => navigate({ kind: "shared" }))}>
                 <Users className="size-4 text-subtle" />
                 Shared with me
+              </Item>
+              <Item onSelect={() => run(() => navigate({ kind: "people" }))}>
+                <User className="size-4 text-subtle" />
+                People
+              </Item>
+              <Item onSelect={() => run(() => navigate({ kind: "companies" }))}>
+                <Building2 className="size-4 text-subtle" />
+                Companies
               </Item>
               <Item onSelect={() => run(() => navigate({ kind: "settings", tab: "preferences" }))}>
                 <Settings className="size-4 text-subtle" />

--- a/desktop/src/components/directory/DirectoryPanel.tsx
+++ b/desktop/src/components/directory/DirectoryPanel.tsx
@@ -1,0 +1,197 @@
+import { useMemo, useState } from "react";
+import { ChevronDown, Search, X } from "lucide-react";
+import { formatDayLabel } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import { Avatar } from "@/components/ui/misc";
+import { Input } from "@/components/ui/input";
+
+export type DirectoryRow = {
+  id: string;
+  title: string;
+  subtitle?: string | null;
+  avatarName: string;
+  lastNoteAt: string | null;
+  noteCount: number;
+};
+
+export function DirectoryPanel({
+  title,
+  subjectColumn,
+  filters,
+  rows,
+  empty,
+  searchPlaceholder,
+}: {
+  title: string;
+  subjectColumn: string;
+  filters: React.ReactNode;
+  rows: DirectoryRow[];
+  empty: React.ReactNode;
+  searchPlaceholder: string;
+}) {
+  const [query, setQuery] = useState("");
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [sortDir, setSortDir] = useState<"desc" | "asc">("desc");
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const filtered = q ? rows.filter((row) => `${row.title} ${row.subtitle ?? ""}`.toLowerCase().includes(q)) : rows;
+    const copy = [...filtered];
+    copy.sort((a, b) => {
+      const av = a.lastNoteAt ?? "";
+      const bv = b.lastNoteAt ?? "";
+      if (av === bv) return a.title.localeCompare(b.title);
+      if (!av) return 1;
+      if (!bv) return -1;
+      return sortDir === "desc" ? bv.localeCompare(av) : av.localeCompare(bv);
+    });
+    return copy;
+  }, [query, rows, sortDir]);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <header className="flex shrink-0 items-center gap-3 px-6 pb-3 pt-2">
+        <h1 className="font-display min-w-0 flex-1 text-[22px] font-semibold tracking-tight text-text">{title}</h1>
+        <div className="flex items-center gap-2">
+          {searchOpen ? (
+            <div className="flex items-center gap-1">
+              <Input
+                autoFocus
+                value={query}
+                placeholder={searchPlaceholder}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    setQuery("");
+                    setSearchOpen(false);
+                  }
+                }}
+                className="h-8 w-52 rounded-full"
+              />
+              <button
+                type="button"
+                aria-label="Close search"
+                onClick={() => {
+                  setQuery("");
+                  setSearchOpen(false);
+                }}
+                className="grid size-8 place-items-center rounded-md text-subtle transition-colors hover:bg-hover hover:text-text"
+              >
+                <X className="size-3.5" />
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              aria-label="Search"
+              onClick={() => setSearchOpen(true)}
+              className="grid size-8 place-items-center rounded-md text-subtle transition-colors hover:bg-hover hover:text-text"
+            >
+              <Search className="size-4" />
+            </button>
+          )}
+          {filters}
+        </div>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-10">
+        <div className="grid grid-cols-[minmax(0,1fr)_7.5rem_4.5rem] gap-x-3 border-b border-border px-1 pb-2 text-[11px] font-medium text-subtle">
+          <div>{subjectColumn}</div>
+          <button
+            type="button"
+            onClick={() => setSortDir((d) => (d === "desc" ? "asc" : "desc"))}
+            className="inline-flex items-center gap-0.5 text-left hover:text-text"
+          >
+            Last note
+            <ChevronDown className={cn("size-3 transition-transform", sortDir === "asc" && "rotate-180")} />
+          </button>
+          <div>Notes</div>
+        </div>
+
+        {visible.map((row) => (
+          <div
+            key={row.id}
+            className="grid grid-cols-[minmax(0,1fr)_7.5rem_4.5rem] items-center gap-x-3 rounded-lg px-1 py-2.5 transition-colors hover:bg-hover"
+          >
+            <div className="flex min-w-0 items-center gap-2.5">
+              <Avatar name={row.avatarName} size={28} />
+              <div className="min-w-0">
+                <div className="truncate text-[13px] font-medium text-text">{row.title}</div>
+                {row.subtitle ? <div className="truncate text-[12px] text-subtle">{row.subtitle}</div> : null}
+              </div>
+            </div>
+            <div className="text-[13px] text-muted">{row.lastNoteAt ? formatDayLabel(row.lastNoteAt) : "—"}</div>
+            <div className="text-[13px] text-muted">{row.noteCount || "—"}</div>
+          </div>
+        ))}
+
+        {empty}
+      </div>
+    </div>
+  );
+}
+
+export function DirectoryFilter({
+  options,
+  value,
+  onChange,
+  variant = "segmented",
+}: {
+  options: { id: string; label: string }[];
+  value: string;
+  onChange: (id: string) => void;
+  variant?: "segmented" | "pill-link";
+}) {
+  if (variant === "pill-link") {
+    return (
+      <div className="flex items-center gap-2">
+        {options.map((option) => {
+          const active = option.id === value;
+          return (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => onChange(option.id)}
+              className={cn(
+                "h-8 rounded-full px-3 text-[13px] transition-colors duration-150",
+                active ? "bg-solid text-solid-fg shadow-xs" : "text-muted hover:bg-hover hover:text-text",
+              )}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-8 items-center rounded-full bg-hover p-0.5">
+      {options.map((option) => {
+        const active = option.id === value;
+        return (
+          <button
+            key={option.id}
+            type="button"
+            onClick={() => onChange(option.id)}
+            className={cn(
+              "h-7 rounded-full px-3 text-[13px] transition-colors duration-150",
+              active ? "bg-solid text-solid-fg shadow-xs" : "text-muted hover:text-text",
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function DirectoryEmpty({ icon, children }: { icon: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-[280px] flex-col items-center justify-center gap-3 text-center">
+      <div className="text-subtle/40 [&_svg]:size-16">{icon}</div>
+      <p className="max-w-xs text-[13px] text-subtle">{children}</p>
+    </div>
+  );
+}

--- a/desktop/src/components/layout/Sidebar.tsx
+++ b/desktop/src/components/layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import {
   ChevronDown,
   ChevronsUpDown,
   CircleHelp,
+  Compass,
   FolderPlus,
   Home,
   LayoutTemplate,
@@ -13,7 +14,7 @@ import {
   Plus,
   Search,
   Settings,
-  SquarePen,
+  User,
   UserPlus,
   Users,
   type LucideIcon,
@@ -194,6 +195,7 @@ export function Sidebar() {
         workspace={workspaceName}
         onSettings={openSettings}
         navigate={navigate}
+        route={route}
       />
 
       <NewFolderDialog
@@ -415,22 +417,35 @@ function SidebarFooter({
   workspace,
   onSettings,
   navigate,
+  route,
 }: {
   name: string;
   email: string;
   workspace: string;
   onSettings: () => void;
   navigate: (route: Route) => void;
+  route: Route;
 }) {
   return (
     <div className="border-t border-border p-2">
       <div className="mb-1.5 flex items-center gap-0.5 px-1">
-        <FooterIcon label="New note" icon={SquarePen} onClick={() => navigate({ kind: "home" })} />
-        <FooterIcon label="People" icon={UserPlus} onClick={() => navigate({ kind: "settings", tab: "members" })} />
         <FooterIcon
           label="Templates"
-          icon={LayoutTemplate}
+          icon={Compass}
+          active={route.kind === "settings" && route.tab === "spaces"}
           onClick={() => navigate({ kind: "settings", tab: "spaces" })}
+        />
+        <FooterIcon
+          label="People"
+          icon={User}
+          active={route.kind === "people"}
+          onClick={() => navigate({ kind: "people" })}
+        />
+        <FooterIcon
+          label="Companies"
+          icon={Building2}
+          active={route.kind === "companies"}
+          onClick={() => navigate({ kind: "companies" })}
         />
       </div>
 
@@ -494,10 +509,12 @@ function FooterIcon({
   label,
   icon: Icon,
   onClick,
+  active,
 }: {
   label: string;
   icon: LucideIcon;
   onClick: () => void;
+  active?: boolean;
 }) {
   return (
     <Tooltip label={label} side="top">
@@ -505,7 +522,12 @@ function FooterIcon({
         type="button"
         aria-label={label}
         onClick={onClick}
-        className="grid size-6 place-items-center rounded-md text-subtle transition-colors hover:bg-hover hover:text-text"
+        className={cn(
+          "grid size-6 place-items-center rounded-md transition-[background-color,color,box-shadow] duration-150",
+          active
+            ? "bg-hover text-text shadow-[inset_0_0_0_1px_var(--border-strong)]"
+            : "text-subtle hover:bg-hover hover:text-text",
+        )}
       >
         <Icon className="size-3.5" />
       </button>

--- a/desktop/src/components/pages/CompaniesPage.tsx
+++ b/desktop/src/components/pages/CompaniesPage.tsx
@@ -1,0 +1,61 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Building2 } from "lucide-react";
+import * as api from "@/lib/api";
+import { mergeDomainCompanies, mergeSelfIntoPeople } from "@/lib/directory";
+import { DirectoryEmpty, DirectoryFilter, DirectoryPanel } from "@/components/directory/DirectoryPanel";
+
+export function CompaniesPage() {
+  const [scope, setScope] = useState<"all" | "met">("all");
+  const { data: profile } = useQuery({ queryKey: api.qk.profile(), queryFn: api.getProfile });
+  const { data: people = [] } = useQuery({ queryKey: api.qk.people(), queryFn: api.listPeople });
+  const { data: companies = [] } = useQuery({ queryKey: api.qk.companies(), queryFn: api.listCompanies });
+  const { data: meetings = [] } = useQuery({ queryKey: api.qk.meetings(), queryFn: () => api.listMeetings() });
+
+  const { rows, metCount } = useMemo(() => {
+    const mergedPeople = mergeSelfIntoPeople(people, profile, meetings);
+    const merged = mergeDomainCompanies(companies, mergedPeople, meetings);
+    const selfDomain = mergedPeople.find((person) => person.is_me)?.domain?.toLowerCase();
+    const met = merged.filter((company) => {
+      const domain = company.domain?.toLowerCase();
+      return company.note_count > 0 && domain !== selfDomain;
+    });
+    const scoped = scope === "met" ? met : merged;
+    return {
+      metCount: met.length,
+      rows: scoped.map((company) => ({
+        id: company.id,
+        title: company.name,
+        subtitle: company.domain,
+        avatarName: company.name,
+        lastNoteAt: company.last_note_at,
+        noteCount: company.note_count,
+      })),
+    };
+  }, [companies, meetings, people, profile, scope]);
+
+  return (
+    <DirectoryPanel
+      title="Companies"
+      subjectColumn="Company"
+      searchPlaceholder="Search companies"
+      filters={
+        <DirectoryFilter
+          variant="pill-link"
+          value={scope}
+          onChange={(id) => setScope(id as "all" | "met")}
+          options={[
+            { id: "all", label: "All companies" },
+            { id: "met", label: "Companies I met" },
+          ]}
+        />
+      }
+      rows={rows}
+      empty={
+        metCount === 0 ? (
+          <DirectoryEmpty icon={<Building2 />}>Companies of people you meet in Bagrry will appear here.</DirectoryEmpty>
+        ) : null
+      }
+    />
+  );
+}

--- a/desktop/src/components/pages/PeoplePage.tsx
+++ b/desktop/src/components/pages/PeoplePage.tsx
@@ -1,0 +1,50 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Users } from "lucide-react";
+import * as api from "@/lib/api";
+import { mergeSelfIntoPeople } from "@/lib/directory";
+import { DirectoryEmpty, DirectoryFilter, DirectoryPanel } from "@/components/directory/DirectoryPanel";
+
+export function PeoplePage() {
+  const [scope, setScope] = useState<"everyone" | "met">("everyone");
+  const { data: profile } = useQuery({ queryKey: api.qk.profile(), queryFn: api.getProfile });
+  const { data: people = [] } = useQuery({ queryKey: api.qk.people(), queryFn: api.listPeople });
+  const { data: meetings = [] } = useQuery({ queryKey: api.qk.meetings(), queryFn: () => api.listMeetings() });
+
+  const merged = useMemo(() => mergeSelfIntoPeople(people, profile, meetings), [meetings, people, profile]);
+  const metCount = merged.filter((person) => !person.is_me && person.note_count > 0).length;
+  const scoped = scope === "met" ? merged.filter((person) => !person.is_me && person.note_count > 0) : merged;
+
+  const rows = scoped.map((person) => ({
+    id: person.id,
+    title: person.is_me ? `${person.name} (me)` : person.name,
+    subtitle: person.email,
+    avatarName: person.name,
+    lastNoteAt: person.last_note_at,
+    noteCount: person.note_count,
+  }));
+
+  return (
+    <DirectoryPanel
+      title="People"
+      subjectColumn="Person"
+      searchPlaceholder="Search people"
+      filters={
+        <DirectoryFilter
+          value={scope}
+          onChange={(id) => setScope(id as "everyone" | "met")}
+          options={[
+            { id: "everyone", label: "Everyone" },
+            { id: "met", label: "People I met" },
+          ]}
+        />
+      }
+      rows={rows}
+      empty={
+        metCount === 0 ? (
+          <DirectoryEmpty icon={<Users />}>People you meet in Bagrry will appear here.</DirectoryEmpty>
+        ) : null
+      }
+    />
+  );
+}

--- a/desktop/src/lib/directory.test.ts
+++ b/desktop/src/lib/directory.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  companyNameFromDomain,
+  filterDirectory,
+  mergeDomainCompanies,
+  mergeSelfIntoPeople,
+  sortByLastNote,
+} from "./directory";
+import type { Company, Meeting, Person, Profile } from "./types";
+
+const profile: Profile = {
+  name: "Dheeraj",
+  email: "btech60084.23@bitmesra.ac.in",
+  workspace: "Dheeraj",
+};
+
+const meetings: Meeting[] = [
+  {
+    id: "m1",
+    folder_id: null,
+    title: "Standup",
+    date: "2026-08-15 10:00:00",
+    duration_ms: null,
+    calendar_event_id: null,
+    scratchpad_raw: "",
+    enhanced_notes_json: null,
+    transcript_json: null,
+    updated_at: "2026-08-15 10:00:00",
+  },
+];
+
+describe("directory helpers", () => {
+  it("names a company from its domain", () => {
+    expect(companyNameFromDomain("bitmesra.ac.in")).toBe("Bitmesra");
+  });
+
+  it("inserts the signed-in user when they are not already in attendees", () => {
+    const people = mergeSelfIntoPeople([], profile, meetings);
+    expect(people).toHaveLength(1);
+    expect(people[0]?.is_me).toBe(true);
+    expect(people[0]?.email).toBe(profile.email);
+    expect(people[0]?.note_count).toBe(1);
+  });
+
+  it("marks an existing attendee as me instead of duplicating", () => {
+    const existing: Person = {
+      id: "p1",
+      name: "Dheeraj Charaungonath",
+      email: profile.email,
+      domain: "bitmesra.ac.in",
+      company_id: null,
+      note_count: 1,
+      last_note_at: meetings[0]!.date,
+    };
+    const people = mergeSelfIntoPeople([existing], profile, meetings);
+    expect(people).toHaveLength(1);
+    expect(people[0]?.is_me).toBe(true);
+    expect(people[0]?.id).toBe("p1");
+  });
+
+  it("synthesizes a company from the user's email domain", () => {
+    const people = mergeSelfIntoPeople([], profile, meetings);
+    const companies = mergeDomainCompanies([], people, meetings);
+    expect(companies).toHaveLength(1);
+    expect(companies[0]?.name).toBe("Bitmesra");
+    expect(companies[0]?.domain).toBe("bitmesra.ac.in");
+  });
+
+  it("hides people with no notes on the People I met filter", () => {
+    const rows: Person[] = [
+      {
+        id: "a",
+        name: "Alex",
+        email: null,
+        domain: null,
+        company_id: null,
+        note_count: 2,
+        last_note_at: "2026-08-01 00:00:00",
+      },
+      {
+        id: "b",
+        name: "Blair",
+        email: null,
+        domain: null,
+        company_id: null,
+        note_count: 0,
+        last_note_at: null,
+      },
+    ];
+    expect(filterDirectory(rows, "", true).map((r) => r.id)).toEqual(["a"]);
+    expect(filterDirectory(rows, "bla", false).map((r) => r.id)).toEqual(["b"]);
+  });
+
+  it("sorts empty last-note rows after dated ones", () => {
+    const rows: Company[] = [
+      { id: "1", name: "Zed", domain: null, note_count: 0, last_note_at: null },
+      { id: "2", name: "Acme", domain: null, note_count: 1, last_note_at: "2026-08-15 00:00:00" },
+    ];
+    expect(sortByLastNote(rows, "desc").map((r) => r.id)).toEqual(["2", "1"]);
+  });
+});

--- a/desktop/src/lib/directory.ts
+++ b/desktop/src/lib/directory.ts
@@ -1,0 +1,111 @@
+import type { Company, Meeting, Person, Profile } from "./types";
+
+export type DirectoryPerson = Person & { is_me?: boolean };
+
+export function emailDomain(email: string | null | undefined): string | null {
+  if (!email || !email.includes("@")) return null;
+  const domain = email.split("@")[1]?.trim().toLowerCase();
+  return domain || null;
+}
+
+/** "bitmesra.ac.in" → "Bitmesra" */
+export function companyNameFromDomain(domain: string): string {
+  const head = domain.split(".")[0]?.trim() ?? domain;
+  if (!head) return domain;
+  return head.charAt(0).toUpperCase() + head.slice(1);
+}
+
+export function mergeSelfIntoPeople(
+  people: Person[],
+  profile: Profile | undefined,
+  meetings: Meeting[],
+): DirectoryPerson[] {
+  const latest = meetings[0]?.date ?? null;
+  const count = meetings.length;
+  const profileEmail = profile?.email.trim().toLowerCase() || null;
+  const profileName = profile?.name.trim() || "You";
+
+  const marked = people.map((person) => {
+    const email = person.email?.trim().toLowerCase() ?? null;
+    const isMe = Boolean(profileEmail && email && email === profileEmail);
+    return {
+      ...person,
+      is_me: isMe,
+      note_count: isMe ? Math.max(person.note_count, count) : person.note_count,
+      last_note_at: isMe ? (person.last_note_at ?? latest) : person.last_note_at,
+    };
+  });
+
+  if (marked.some((person) => person.is_me) || !profile) return marked;
+
+  return [
+    {
+      id: "person_me",
+      name: profileName,
+      email: profile.email || null,
+      domain: emailDomain(profile.email),
+      company_id: null,
+      note_count: count,
+      last_note_at: latest,
+      is_me: true,
+    },
+    ...marked,
+  ];
+}
+
+export function mergeDomainCompanies(companies: Company[], people: DirectoryPerson[], meetings: Meeting[]): Company[] {
+  const byDomain = new Map<string, Company>();
+  for (const company of companies) {
+    if (company.domain) byDomain.set(company.domain.toLowerCase(), company);
+  }
+
+  const extra: Company[] = [];
+  for (const person of people) {
+    const domain = (person.domain || emailDomain(person.email))?.toLowerCase();
+    if (!domain || byDomain.has(domain)) continue;
+    const latest = person.is_me ? (meetings[0]?.date ?? person.last_note_at) : person.last_note_at;
+    const count = person.is_me ? Math.max(person.note_count, meetings.length) : person.note_count;
+    const synthesized: Company = {
+      id: `company_domain:${domain}`,
+      name: companyNameFromDomain(domain),
+      domain,
+      note_count: count,
+      last_note_at: latest,
+    };
+    byDomain.set(domain, synthesized);
+    extra.push(synthesized);
+  }
+
+  return [...companies, ...extra];
+}
+
+export function filterDirectory<T extends { name: string; note_count: number }>(
+  rows: T[],
+  query: string,
+  metOnly: boolean,
+  extraHaystack?: (row: T) => string,
+): T[] {
+  const q = query.trim().toLowerCase();
+  return rows.filter((row) => {
+    if (metOnly && row.note_count <= 0) return false;
+    if (!q) return true;
+    const hay = `${row.name} ${extraHaystack?.(row) ?? ""}`.toLowerCase();
+    return hay.includes(q);
+  });
+}
+
+export function sortByLastNote<T extends { last_note_at: string | null; name: string }>(
+  rows: T[],
+  dir: "desc" | "asc" = "desc",
+): T[] {
+  const copy = [...rows];
+  copy.sort((a, b) => {
+    const av = a.last_note_at ?? "";
+    const bv = b.last_note_at ?? "";
+    if (av === bv) return a.name.localeCompare(b.name);
+    if (!av) return 1;
+    if (!bv) return -1;
+    return dir === "desc" ? bv.localeCompare(av) : av.localeCompare(bv);
+  });
+  return copy;
+}

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -98,12 +98,16 @@ export type Person = {
   email: string | null;
   domain: string | null;
   company_id: string | null;
+  note_count: number;
+  last_note_at: string | null;
 };
 
 export type Company = {
   id: string;
   name: string;
   domain: string | null;
+  note_count: number;
+  last_note_at: string | null;
 };
 
 export type CalendarEvent = {
@@ -180,6 +184,8 @@ export type Route =
   | { kind: "chat"; sessionId: string | null }
   | { kind: "space"; spaceId: string }
   | { kind: "note"; noteId: string }
+  | { kind: "people" }
+  | { kind: "companies" }
   | { kind: "settings"; tab: SettingsTab };
 
 export function routeKey(route: Route): string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
People and Companies are now first-class panels, opened from the sidebar footer the way they are in the reference UI.

**Sidebar**
- Footer icons are Compass (templates), Person (People), and Building (Companies)
- The active icon gets a light inset border

**People**
- Left-aligned title, search, and Everyone / People I met segmented control
- Table: Person, Last note, Notes
- Signed-in user is listed as `(me)`
- Empty illustration when you have not met anyone yet: “People you meet in Bagrry will appear here.”

**Companies**
- Same directory chrome with All companies / Companies I met
- Table: Company, Last note, Notes
- Your email domain is shown as a company when it is not already in the catalog
- Empty illustration: “Companies of people you meet in Bagrry will appear here.”

Last-note and note counts come from attendees linked to meetings. Both views are also in the command palette under Go to.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

