### PR TITLE
Open Settings in the app sidebar

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -56,7 +56,7 @@ export default function App() {
             <main className="relative min-h-0 flex-1 overflow-hidden">
               <AnimatePresence mode="sync" initial={false}>
                 <motion.div
-                  key={routeKey(route)}
+                  key={route.kind === "settings" ? "settings" : routeKey(route)}
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
                   exit={{ opacity: 0 }}

--- a/desktop/src/components/layout/SettingsSidebar.tsx
+++ b/desktop/src/components/layout/SettingsSidebar.tsx
@@ -1,0 +1,82 @@
+import { useQuery } from "@tanstack/react-query";
+import { LogOut } from "lucide-react";
+import * as api from "@/lib/api";
+import { SETTINGS_PERSONAL_NAV, SETTINGS_WORKSPACE_NAV, type SettingsNavEntry } from "@/lib/settings-nav";
+import type { SettingsTab } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { SIDEBAR_WIDTH } from "@/lib/motion";
+import { useAppStore } from "@/store/app";
+import { Avatar } from "@/components/ui/misc";
+import { toast } from "@/components/ui/toast";
+
+export function SettingsSidebar({ tab }: { tab: SettingsTab }) {
+  const navigate = useAppStore((s) => s.navigate);
+  const back = useAppStore((s) => s.back);
+  const { data: profile } = useQuery({ queryKey: api.qk.profile(), queryFn: api.getProfile });
+
+  const go = (next: SettingsTab) => {
+    navigate({ kind: "settings", tab: next }, { replace: true });
+  };
+
+  return (
+    <aside className="flex h-full shrink-0 flex-col border-r border-border bg-sidebar" style={{ width: SIDEBAR_WIDTH }}>
+      <div data-tauri-drag-region className="flex items-center gap-2.5 px-3 py-3">
+        <Avatar name={profile?.name || "You"} size={32} />
+        <div className="min-w-0">
+          <div className="truncate text-[13px] font-medium text-text">{profile?.name || "You"}</div>
+          <div className="truncate text-[11px] text-subtle">{profile?.email || "No email set"}</div>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-2 scrollbar-none">
+        {SETTINGS_PERSONAL_NAV.map((entry) => (
+          <SettingsNavButton key={entry.tab} entry={entry} active={tab === entry.tab} onClick={go} />
+        ))}
+
+        <div className="mt-4 px-2 pb-1 text-[11px] font-semibold text-subtle">Workspace</div>
+        {SETTINGS_WORKSPACE_NAV.map((entry) => (
+          <SettingsNavButton key={entry.tab} entry={entry} active={tab === entry.tab} onClick={go} />
+        ))}
+      </div>
+
+      <div className="p-2">
+        <button
+          type="button"
+          onClick={() => {
+            toast.success("Signed out", "Bagrry keeps notes on this device — there's no cloud account.");
+            back();
+          }}
+          className="flex h-8 w-full items-center gap-2 rounded-lg px-2 text-left text-[13px] text-danger transition-colors hover:bg-hover"
+        >
+          <LogOut className="size-4 shrink-0" />
+          Sign out
+        </button>
+      </div>
+    </aside>
+  );
+}
+
+function SettingsNavButton({
+  entry,
+  active,
+  onClick,
+}: {
+  entry: SettingsNavEntry;
+  active: boolean;
+  onClick: (tab: SettingsTab) => void;
+}) {
+  const Icon = entry.icon;
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(entry.tab)}
+      className={cn(
+        "flex h-8 w-full items-center gap-2 rounded-lg px-2 text-left text-[13px] transition-colors duration-150",
+        active ? "bg-selected font-medium text-text" : "text-muted hover:bg-hover hover:text-text",
+      )}
+    >
+      <Icon className="size-4 shrink-0" />
+      {entry.label}
+    </button>
+  );
+}

--- a/desktop/src/components/layout/Sidebar.tsx
+++ b/desktop/src/components/layout/Sidebar.tsx
@@ -37,10 +37,43 @@ import {
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { SIDEBAR_WIDTH, layoutTween } from "@/lib/motion";
+import { SIDEBAR_WIDTH, layoutTween, snappy } from "@/lib/motion";
 import { AnimatePresence, motion } from "framer-motion";
+import { SettingsSidebar } from "@/components/layout/SettingsSidebar";
 
 export function Sidebar() {
+  const route = useAppStore((s) => s.route);
+
+  return (
+    <AnimatePresence mode="wait" initial={false}>
+      {route.kind === "settings" ? (
+        <motion.div
+          key="settings"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={snappy}
+          className="h-full"
+        >
+          <SettingsSidebar tab={route.tab} />
+        </motion.div>
+      ) : (
+        <motion.div
+          key="app"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={snappy}
+          className="h-full"
+        >
+          <AppSidebar />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+function AppSidebar() {
   const route = useAppStore((s) => s.route);
   const navigate = useAppStore((s) => s.navigate);
   const openSettings = useAppStore((s) => s.openSettings);

--- a/desktop/src/components/layout/TitleBar.tsx
+++ b/desktop/src/components/layout/TitleBar.tsx
@@ -25,11 +25,30 @@ export function TitleBar() {
   const createNote = useCreateNote();
   const showNewNote = route.kind === "home" || route.kind === "space" || route.kind === "shared";
 
+  if (route.kind === "settings") {
+    return (
+      <header data-tauri-drag-region className="relative flex h-11 shrink-0 items-center pl-3 pr-0">
+        <Tooltip label="Back" shortcut="Alt+←">
+          <button
+            type="button"
+            aria-label="Back"
+            onClick={back}
+            className="grid size-7 place-items-center rounded-md text-muted transition-colors hover:bg-hover hover:text-text"
+          >
+            <ChevronLeft className="size-4" />
+          </button>
+        </Tooltip>
+        <div className="pointer-events-none absolute inset-0 grid place-items-center text-[13px] font-medium text-text">
+          Settings
+        </div>
+        <div data-tauri-drag-region className="h-full flex-1" />
+        <WindowControls />
+      </header>
+    );
+  }
+
   return (
-    <header
-      data-tauri-drag-region
-      className="flex h-11 shrink-0 items-center gap-2 pl-3 pr-0"
-    >
+    <header data-tauri-drag-region className="flex h-11 shrink-0 items-center gap-2 pl-3 pr-0">
       <div className="flex items-center gap-0.5 rounded-lg border border-border bg-surface p-0.5">
         <AnimatePresence initial={false}>
           {history.length > 0 && (
@@ -107,9 +126,7 @@ function RecordingPill() {
       onClick={() => meetingId && openNote(meetingId)}
       className="flex h-6 items-center gap-1.5 rounded-full bg-danger/12 px-2 text-[11px] font-medium text-danger transition-colors hover:bg-danger/20"
     >
-      <span
-        className={cn("size-1.5 rounded-full bg-danger", recState === "recording" && "animate-pulse-ring")}
-      />
+      <span className={cn("size-1.5 rounded-full bg-danger", recState === "recording" && "animate-pulse-ring")} />
       {recState === "recording" ? "Recording" : "Paused"}
     </button>
   );

--- a/desktop/src/components/pages/SettingsPage.tsx
+++ b/desktop/src/components/pages/SettingsPage.tsx
@@ -1,34 +1,29 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  BarChart3,
   Bell,
-  Blocks,
-  Building2,
   CalendarDays,
-  CircleHelp,
+  ChevronRight,
   CreditCard,
   Database,
   Eye,
+  Gift,
   KeyRound,
   Link2,
   LogIn,
+  Mail,
   Moon,
-  Palette,
   Plus,
   Radio,
   ShieldCheck,
   Tags,
   Trash2,
-  User,
   Users,
   Webhook,
-  type LucideIcon,
 } from "lucide-react";
 import * as api from "@/lib/api";
 import type { SettingsTab } from "@/lib/types";
 import type { ThemePreference } from "@/lib/theme";
-import { cn } from "@/lib/utils";
 import { useAppStore } from "@/store/app";
 import { useBoolSetting, useSetting } from "@/hooks/useSetting";
 import { Avatar, Badge, EmptyState } from "@/components/ui/misc";
@@ -48,109 +43,40 @@ import { toast } from "@/components/ui/toast";
 import { AnimatePresence, motion } from "framer-motion";
 import { snappy } from "@/lib/motion";
 
-type NavEntry = { tab: SettingsTab; label: string; icon: LucideIcon };
-
-const PERSONAL_NAV: NavEntry[] = [
-  { tab: "preferences", label: "Preferences", icon: Palette },
-  { tab: "profile", label: "Profile", icon: User },
-  { tab: "calendar", label: "Calendar", icon: CalendarDays },
-  { tab: "notifications", label: "Notifications", icon: Bell },
-  { tab: "connectors", label: "Connectors", icon: Blocks },
-  { tab: "help", label: "Get help", icon: CircleHelp },
-];
-
-const WORKSPACE_NAV: NavEntry[] = [
-  { tab: "workspace-general", label: "General", icon: Building2 },
-  { tab: "members", label: "Members", icon: Users },
-  { tab: "spaces", label: "Spaces", icon: Blocks },
-  { tab: "analytics", label: "Analytics", icon: BarChart3 },
-  { tab: "billing", label: "Billing", icon: CreditCard },
-];
-
 export function SettingsPage({ tab }: { tab: SettingsTab }) {
-  const navigate = useAppStore((s) => s.navigate);
-  const { data: profile } = useQuery({ queryKey: api.qk.profile(), queryFn: api.getProfile });
-
   return (
-    <div className="flex h-full min-h-0">
-      <nav className="flex w-[212px] shrink-0 flex-col border-r border-border bg-sidebar p-2">
-        <div className="mb-3 flex items-center gap-2 px-1.5 pt-1">
-          <Avatar name={profile?.name || "You"} size={30} />
-          <div className="min-w-0">
-            <div className="truncate text-[13px] font-medium text-text">{profile?.name || "You"}</div>
-            <div className="truncate text-[11px] text-subtle">{profile?.email || "No email set"}</div>
-          </div>
-        </div>
-
-        <div className="min-h-0 flex-1 overflow-y-auto scrollbar-none">
-          {PERSONAL_NAV.map((entry) => (
-            <NavButton key={entry.tab} entry={entry} active={tab === entry.tab} onClick={navigate} />
-          ))}
-
-          <div className="mt-4 px-2 pb-1 text-[11px] font-semibold text-subtle">Workspace</div>
-          {WORKSPACE_NAV.map((entry) => (
-            <NavButton key={entry.tab} entry={entry} active={tab === entry.tab} onClick={navigate} />
-          ))}
-        </div>
-      </nav>
-
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        <AnimatePresence mode="wait" initial={false}>
-          <motion.div
-            key={tab}
-            initial={{ opacity: 0, y: 4 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0 }}
-            transition={snappy}
-            className="mx-auto w-full max-w-[620px] px-8 pb-16 pt-6"
-          >
-            {tab === "preferences" && <PreferencesTab />}
-            {tab === "profile" && <ProfileTab />}
-            {tab === "calendar" && <CalendarTab />}
-            {tab === "notifications" && <NotificationsTab />}
-            {tab === "connectors" && <ConnectorsTab />}
-            {tab === "help" && <HelpTab />}
-            {tab === "workspace-general" && <WorkspaceGeneralTab />}
-            {tab === "members" && <MembersTab />}
-            {tab === "spaces" && <SpacesTab />}
-            {tab === "analytics" && <AnalyticsTab />}
-            {tab === "billing" && <BillingTab />}
-          </motion.div>
-        </AnimatePresence>
-      </div>
+    <div className="h-full min-h-0 overflow-y-auto">
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.div
+          key={tab}
+          initial={{ opacity: 0, y: 4 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0 }}
+          transition={snappy}
+          className="mx-auto w-full max-w-[620px] px-8 pb-16 pt-6"
+        >
+          {tab === "preferences" && <PreferencesTab />}
+          {tab === "profile" && <ProfileTab />}
+          {tab === "calendar" && <CalendarTab />}
+          {tab === "notifications" && <NotificationsTab />}
+          {tab === "connectors" && <ConnectorsTab />}
+          {tab === "help" && <HelpTab />}
+          {tab === "workspace-general" && <WorkspaceGeneralTab />}
+          {tab === "members" && <MembersTab />}
+          {tab === "spaces" && <SpacesTab />}
+          {tab === "analytics" && <AnalyticsTab />}
+          {tab === "billing" && <BillingTab />}
+          {tab === "referrals" && <ReferralsTab />}
+        </motion.div>
+      </AnimatePresence>
     </div>
-  );
-}
-
-function NavButton({
-  entry,
-  active,
-  onClick,
-}: {
-  entry: NavEntry;
-  active: boolean;
-  onClick: (route: { kind: "settings"; tab: SettingsTab }) => void;
-}) {
-  const Icon = entry.icon;
-  return (
-    <button
-      type="button"
-      onClick={() => onClick({ kind: "settings", tab: entry.tab })}
-      className={cn(
-        "flex h-8 w-full items-center gap-2 rounded-lg px-2 text-left text-[13px] transition-colors",
-        active ? "bg-selected font-medium text-text" : "text-muted hover:bg-hover hover:text-text",
-      )}
-    >
-      <Icon className="size-4 shrink-0" />
-      {entry.label}
-    </button>
   );
 }
 
 function TabHeading({ title, description }: { title: string; description?: string }) {
   return (
-    <header className="mb-5">
-      <h1 className="font-display text-[24px] font-semibold text-text">{title}</h1>
+    <header className="mb-6">
+      <h1 className="font-display text-[30px] font-semibold tracking-tight text-text">{title}</h1>
       {description && <p className="mt-1 text-[13px] text-muted">{description}</p>}
     </header>
   );
@@ -169,12 +95,14 @@ const THEME_OPTIONS: { value: ThemePreference; label: string }[] = [
 function PreferencesTab() {
   const themePreference = useAppStore((s) => s.themePreference);
   const setThemePreference = useAppStore((s) => s.setThemePreference);
+  const navigate = useAppStore((s) => s.navigate);
   const [, persistTheme] = useSetting("theme", "system");
 
   const [indicator, setIndicator] = useBoolSetting("live_indicator", true);
   const [launchOnLogin, setLaunchOnLogin] = useBoolSetting("launch_on_login", false);
   const [reposition, setReposition] = useBoolSetting("reposition_for_meetings", false);
   const [speakerTags, setSpeakerTags] = useBoolSetting("speaker_tags", false);
+  const [followUpEmails, setFollowUpEmails] = useBoolSetting("suggested_follow_up_emails", false);
   const [linkSharing, setLinkSharing] = useSetting("default_link_sharing", "workspace");
   const [improveModels, setImproveModels] = useBoolSetting("improve_models", false);
   const [retention, setRetention] = useSetting("transcript_retention", "off");
@@ -209,7 +137,22 @@ function PreferencesTab() {
           icon={<Tags />}
           title="Speaker tags"
           description="Identify who is speaking in your calls."
-          control={<Switch checked={speakerTags} onCheckedChange={setSpeakerTags} />}
+          control={
+            <button
+              type="button"
+              onClick={() => setSpeakerTags(!speakerTags)}
+              className="inline-flex items-center gap-0.5 text-[13px] text-muted transition-colors hover:text-text"
+            >
+              {speakerTags ? "On" : "Off"}
+              <ChevronRight className="size-3.5" />
+            </button>
+          }
+        />
+        <SettingRow
+          icon={<Mail />}
+          title="Suggested follow-up emails"
+          description="Draft a recap email after a meeting is enhanced."
+          control={<Switch checked={followUpEmails} onCheckedChange={setFollowUpEmails} />}
         />
       </SettingsCard>
 
@@ -263,7 +206,18 @@ function PreferencesTab() {
         <SettingRow
           icon={<ShieldCheck />}
           title="Use my data to improve models"
-          description="Anonymised transcripts help improve summary quality."
+          description={
+            <>
+              Anonymised transcripts help improve summary quality.{" "}
+              <button
+                type="button"
+                className="text-accent hover:underline"
+                onClick={() => navigate({ kind: "settings", tab: "help" }, { replace: true })}
+              >
+                Learn more
+              </button>
+            </>
+          }
           control={<Switch checked={improveModels} onCheckedChange={setImproveModels} />}
         />
         <SettingRow
@@ -300,11 +254,7 @@ function ProfileTab() {
 
   const save = useMutation({
     mutationFn: () =>
-      api.setProfile(
-        name ?? profile?.name ?? "",
-        email ?? profile?.email ?? "",
-        profile?.workspace ?? "",
-      ),
+      api.setProfile(name ?? profile?.name ?? "", email ?? profile?.email ?? "", profile?.workspace ?? ""),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: api.qk.profile() });
       toast.success("Profile saved");
@@ -318,9 +268,7 @@ function ProfileTab() {
 
       <div className="mb-5 flex items-center gap-3">
         <Avatar name={profile?.name || "You"} size={52} />
-        <div className="text-xs text-subtle">
-          Avatars are generated from your name.
-        </div>
+        <div className="text-xs text-subtle">Avatars are generated from your name.</div>
       </div>
 
       <div className="space-y-4">
@@ -403,9 +351,7 @@ function CalendarTab() {
         {events.length === 0 ? (
           <EmptyState icon={<CalendarDays />} title="No events yet" />
         ) : (
-          events.map((event) => (
-            <SettingRow key={event.id} title={event.title} description={event.start_at} />
-          ))
+          events.map((event) => <SettingRow key={event.id} title={event.title} description={event.start_at} />)
         )}
       </SettingsCard>
     </>
@@ -475,20 +421,11 @@ function ConnectorsTab() {
         <SettingRow
           icon={<KeyRound />}
           title="API key"
-          description={
-            status?.groq_configured ? "A key is configured." : "No key yet — AI features are disabled."
-          }
-          control={
-            status?.groq_configured ? <Badge tone="success">Connected</Badge> : <Badge>Not set</Badge>
-          }
+          description={status?.groq_configured ? "A key is configured." : "No key yet — AI features are disabled."}
+          control={status?.groq_configured ? <Badge tone="success">Connected</Badge> : <Badge>Not set</Badge>}
         />
         <div className="flex gap-2 p-4">
-          <Input
-            type="password"
-            placeholder="gsk_..."
-            value={groqKey}
-            onChange={(e) => setGroqKey(e.target.value)}
-          />
+          <Input type="password" placeholder="gsk_..." value={groqKey} onChange={(e) => setGroqKey(e.target.value)} />
           <Button
             variant="solid"
             size="md"
@@ -517,11 +454,7 @@ function ConnectorsTab() {
       </SettingsCard>
 
       <SettingsCard title="Local database">
-        <SettingRow
-          icon={<Database />}
-          title="SQLite file"
-          description={status?.path ?? "Loading…"}
-        />
+        <SettingRow icon={<Database />} title="SQLite file" description={status?.path ?? "Loading…"} />
         <SettingRow
           icon={<Database />}
           title="Notes stored"
@@ -571,8 +504,7 @@ function WorkspaceGeneralTab() {
   const [workspace, setWorkspace] = useState<string | null>(null);
 
   const save = useMutation({
-    mutationFn: () =>
-      api.setProfile(profile?.name ?? "", profile?.email ?? "", (workspace ?? "").trim()),
+    mutationFn: () => api.setProfile(profile?.name ?? "", profile?.email ?? "", (workspace ?? "").trim()),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: api.qk.profile() });
       toast.success("Workspace renamed");
@@ -585,10 +517,7 @@ function WorkspaceGeneralTab() {
       <TabHeading title="General" description="Workspace-wide settings." />
       <div className="space-y-4">
         <Field label="Workspace name">
-          <Input
-            value={workspace ?? profile?.workspace ?? ""}
-            onChange={(e) => setWorkspace(e.target.value)}
-          />
+          <Input value={workspace ?? profile?.workspace ?? ""} onChange={(e) => setWorkspace(e.target.value)} />
         </Field>
         <Button
           variant="solid"
@@ -745,6 +674,22 @@ function BillingTab() {
           title="Plan"
           description="Bagrry runs entirely on your machine. Bring your own Groq key."
           control={<Badge tone="accent">Local</Badge>}
+        />
+      </SettingsCard>
+    </>
+  );
+}
+
+function ReferralsTab() {
+  return (
+    <>
+      <TabHeading title="Referrals" description="Invite teammates to your workspace." />
+      <SettingsCard>
+        <SettingRow
+          icon={<Gift />}
+          title="Share Bagrry"
+          description="Bagrry is local-first — send someone the app, not a cloud invite."
+          control={<Badge>Soon</Badge>}
         />
       </SettingsCard>
     </>

--- a/desktop/src/lib/settings-nav.test.ts
+++ b/desktop/src/lib/settings-nav.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { SETTINGS_PERSONAL_NAV, SETTINGS_WORKSPACE_NAV } from "./settings-nav";
+
+describe("settings nav", () => {
+  it("lists personal items with Preferences first", () => {
+    expect(SETTINGS_PERSONAL_NAV.map((e) => e.tab)).toEqual([
+      "preferences",
+      "profile",
+      "calendar",
+      "notifications",
+      "connectors",
+      "help",
+    ]);
+  });
+
+  it("lists workspace items including Referrals", () => {
+    expect(SETTINGS_WORKSPACE_NAV.map((e) => e.tab)).toEqual([
+      "workspace-general",
+      "members",
+      "spaces",
+      "analytics",
+      "billing",
+      "referrals",
+    ]);
+  });
+});

--- a/desktop/src/lib/settings-nav.ts
+++ b/desktop/src/lib/settings-nav.ts
@@ -1,0 +1,36 @@
+import {
+  AppWindow,
+  BarChart3,
+  Bell,
+  CalendarDays,
+  CircleHelp,
+  CreditCard,
+  Folder,
+  Gift,
+  LayoutGrid,
+  SlidersHorizontal,
+  User,
+  Users,
+  type LucideIcon,
+} from "lucide-react";
+import type { SettingsTab } from "./types";
+
+export type SettingsNavEntry = { tab: SettingsTab; label: string; icon: LucideIcon };
+
+export const SETTINGS_PERSONAL_NAV: SettingsNavEntry[] = [
+  { tab: "preferences", label: "Preferences", icon: SlidersHorizontal },
+  { tab: "profile", label: "Profile", icon: User },
+  { tab: "calendar", label: "Calendar", icon: CalendarDays },
+  { tab: "notifications", label: "Notifications", icon: Bell },
+  { tab: "connectors", label: "Connectors", icon: LayoutGrid },
+  { tab: "help", label: "Get help", icon: CircleHelp },
+];
+
+export const SETTINGS_WORKSPACE_NAV: SettingsNavEntry[] = [
+  { tab: "workspace-general", label: "General", icon: AppWindow },
+  { tab: "members", label: "Members", icon: Users },
+  { tab: "spaces", label: "Spaces", icon: Folder },
+  { tab: "analytics", label: "Analytics", icon: BarChart3 },
+  { tab: "billing", label: "Billing", icon: CreditCard },
+  { tab: "referrals", label: "Referrals", icon: Gift },
+];

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -172,7 +172,8 @@ export type SettingsTab =
   | "members"
   | "spaces"
   | "analytics"
-  | "billing";
+  | "billing"
+  | "referrals";
 
 export type Route =
   | { kind: "home" }

--- a/desktop/src/store/app.ts
+++ b/desktop/src/store/app.ts
@@ -106,7 +106,10 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   openNote: (id) => get().navigate({ kind: "note", noteId: id }),
   openSpace: (id) => get().navigate({ kind: "space", spaceId: id || MY_NOTES_SPACE }),
-  openSettings: (tab = "preferences") => get().navigate({ kind: "settings", tab }),
+  openSettings: (tab = "preferences") => {
+    if (!get().sidebarOpen) get().setSidebarOpen(true);
+    get().navigate({ kind: "settings", tab });
+  },
 
   sidebarOpen: readFlag(SIDEBAR_KEY, true),
   toggleSidebar: () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Opening Settings now replaces the app sidebar with the settings list, instead of nesting a second nav inside the content pane.

**Sidebar**
- Profile at the top
- Preferences, Profile, Calendar, Notifications, Connectors, Get help
- Workspace: General, Members, Spaces, Analytics, Billing, Referrals
- Sign out at the bottom
- Switching tabs does not stack Back history; Back leaves Settings

**Content**
- Title bar shows a back control and a centered **Settings** label
- The pane is only the selected section (Preferences uses the large display title and grouped cards)
- Opening Settings also re-opens the sidebar if it was collapsed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

