### PR TITLE
Make the sidebar slide closed instead of vanishing

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -9,6 +9,7 @@ import { routeKey, type RecStatus, type VuLevels } from "@/lib/types";
 import { useAppStore } from "@/store/app";
 import { useGlobalShortcuts } from "@/hooks/useGlobalShortcuts";
 import { Sidebar } from "@/components/layout/Sidebar";
+import { SidebarRail } from "@/components/layout/SidebarRail";
 import { TitleBar } from "@/components/layout/TitleBar";
 import { CommandPalette } from "@/components/CommandPalette";
 import { Onboarding } from "@/components/Onboarding";
@@ -21,7 +22,7 @@ import { SharedPage } from "@/components/pages/SharedPage";
 import { PeoplePage } from "@/components/pages/PeoplePage";
 import { CompaniesPage } from "@/components/pages/CompaniesPage";
 import { SettingsPage } from "@/components/pages/SettingsPage";
-import { sidebarTween, SIDEBAR_WIDTH, snappy } from "@/lib/motion";
+import { snappy } from "@/lib/motion";
 
 export default function App() {
   const route = useAppStore((s) => s.route);
@@ -36,29 +37,9 @@ export default function App() {
     <MotionConfig reducedMotion="user">
       <TooltipProvider delayDuration={350} skipDelayDuration={200}>
         <div className="flex h-full w-full overflow-hidden bg-bg text-text">
-          <AnimatePresence initial={false}>
-            {sidebarOpen && (
-              <motion.div
-                key="sidebar"
-                initial={{ width: 0 }}
-                animate={{ width: SIDEBAR_WIDTH }}
-                exit={{ width: 0 }}
-                transition={sidebarTween}
-                className="relative h-full shrink-0 overflow-hidden"
-              >
-                <motion.div
-                  initial={{ x: -SIDEBAR_WIDTH }}
-                  animate={{ x: 0 }}
-                  exit={{ x: -SIDEBAR_WIDTH }}
-                  transition={sidebarTween}
-                  className="absolute inset-y-0 left-0 h-full"
-                  style={{ width: SIDEBAR_WIDTH }}
-                >
-                  <Sidebar />
-                </motion.div>
-              </motion.div>
-            )}
-          </AnimatePresence>
+          <SidebarRail open={sidebarOpen}>
+            <Sidebar />
+          </SidebarRail>
 
           <div className="flex min-w-0 flex-1 flex-col bg-bg">
             <TitleBar />

--- a/desktop/src/components/layout/SidebarRail.test.tsx
+++ b/desktop/src/components/layout/SidebarRail.test.tsx
@@ -1,0 +1,27 @@
+/// <reference types="vitest/globals" />
+import { render, screen } from "@testing-library/react";
+import { SidebarRail } from "./SidebarRail";
+
+describe("SidebarRail", () => {
+  it("stays mounted while closed so the slide can play", () => {
+    const { rerender, container } = render(
+      <SidebarRail open>
+        <div>Notes</div>
+      </SidebarRail>,
+    );
+
+    const rail = container.querySelector(".sidebar-rail");
+    expect(rail).toHaveAttribute("data-open", "true");
+    expect(screen.getByText("Notes")).toBeInTheDocument();
+
+    rerender(
+      <SidebarRail open={false}>
+        <div>Notes</div>
+      </SidebarRail>,
+    );
+
+    expect(rail).toHaveAttribute("data-open", "false");
+    expect(screen.getByText("Notes")).toBeInTheDocument();
+    expect(container.querySelector(".sidebar-rail-inner")).toHaveAttribute("aria-hidden", "true");
+  });
+});

--- a/desktop/src/components/layout/SidebarRail.tsx
+++ b/desktop/src/components/layout/SidebarRail.tsx
@@ -1,0 +1,21 @@
+import type { CSSProperties, ReactNode } from "react";
+import { SIDEBAR_WIDTH } from "@/lib/motion";
+
+/**
+ * Keeps the sidebar mounted and slides it with CSS.
+ * Unmounting through AnimatePresence skipped the exit tween, so the rail
+ * vanished in one frame.
+ */
+export function SidebarRail({ open, children }: { open: boolean; children: ReactNode }) {
+  return (
+    <div
+      className="sidebar-rail"
+      data-open={open ? "true" : "false"}
+      style={{ "--sidebar-width": `${SIDEBAR_WIDTH}px` } as CSSProperties}
+    >
+      <div className="sidebar-rail-inner" inert={!open} aria-hidden={!open}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -13,8 +13,10 @@
   --motion-fast: 120ms;
   --motion: 160ms;
   --motion-layout: 200ms;
+  --motion-sidebar: 280ms;
   --motion-out: cubic-bezier(0.22, 1, 0.36, 1);
   --motion-in: cubic-bezier(0.4, 0, 1, 1);
+  --ease-sidebar: cubic-bezier(0.4, 0, 0.2, 1);
 
   /* Surfaces, from furthest back to closest to the user */
   --bg: #f6f5f2;
@@ -413,6 +415,32 @@
 }
 .ui-dialog[data-state="closed"] {
   animation: dialog-out var(--motion-fast) var(--motion-in) both;
+}
+
+/* Sidebar rail: always mounted. Width collapses the slot; inner translate
+   slides the panel as a solid piece instead of clipping it away. */
+.sidebar-rail {
+  --sidebar-width: 208px;
+  position: relative;
+  height: 100%;
+  width: var(--sidebar-width);
+  min-width: 0;
+  flex-shrink: 0;
+  overflow: hidden;
+  transition: width var(--motion-sidebar) var(--ease-sidebar);
+}
+.sidebar-rail[data-open="false"] {
+  width: 0;
+}
+.sidebar-rail-inner {
+  height: 100%;
+  width: var(--sidebar-width);
+  will-change: transform;
+  transform: translate3d(0, 0, 0);
+  transition: transform var(--motion-sidebar) var(--ease-sidebar);
+}
+.sidebar-rail[data-open="false"] .sidebar-rail-inner {
+  transform: translate3d(-100%, 0, 0);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/desktop/src/lib/motion.ts
+++ b/desktop/src/lib/motion.ts
@@ -7,7 +7,8 @@ export const duration = {
   fast: 0.12,
   base: 0.16,
   layout: 0.2,
-  sidebar: 0.18,
+  /** Keep in sync with `--motion-sidebar` in index.css. */
+  sidebar: 0.28,
 } as const;
 
 export const snappy = { duration: duration.base, ease: EASE_OUT };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The sidebar close was instant because the rail **unmounted** through `AnimatePresence`. In this React 19 + Framer setup the exit tween never ran, so width/x jumped to zero in one frame.

This keeps the sidebar mounted and slides it with CSS:

- Outer slot width `208px → 0` so the note pane grows with the motion
- Inner panel `translateX(0 → -100%)` so the rail slides as a solid piece instead of clipping away
- 280ms ease-in-out so the close is actually visible
- `inert` / `aria-hidden` while closed

Toggle with the title-bar control or Ctrl+\\ — both open and close should now slide.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

