### PR TITLE
Make every Settings tab functional

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -327,6 +327,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,7 +355,9 @@ dependencies = [
  "sqlite-vec",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-global-shortcut",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tiny_http",
  "ureq",
@@ -1017,11 +1030,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -1032,7 +1065,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1165,7 +1198,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.4+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2538,6 +2571,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,6 +2761,20 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite 2.6.1",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus 5.19.0",
 ]
 
 [[package]]
@@ -2950,6 +3011,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3427,8 +3489,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3438,7 +3510,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3448,6 +3530,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3463,6 +3554,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3762,7 +3864,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand",
+ "rand 0.8.7",
  "serde",
  "sha2",
  "zbus 3.15.2",
@@ -4315,7 +4417,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -4365,7 +4467,7 @@ checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4436,6 +4538,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "tauri-plugin-global-shortcut"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4448,6 +4564,25 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.20",
+]
+
+[[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.9.5",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.20",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -4570,6 +4705,17 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.4+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.20",
+ "windows 0.61.3",
+ "windows-version",
 ]
 
 [[package]]
@@ -4931,7 +5077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "045979e3f037cd18ad1cb2a419dfda133c5c29c9f3453370079f2255d46c257e"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -5906,6 +6052,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -5936,7 +6091,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",
@@ -6074,7 +6229,7 @@ dependencies = [
  "nix",
  "once_cell",
  "ordered-stream",
- "rand",
+ "rand 0.8.7",
  "serde",
  "serde_repr",
  "sha1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -20,6 +20,8 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
 tauri-plugin-global-shortcut = "2"
+tauri-plugin-autostart = "2"
+tauri-plugin-notification = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -14,7 +14,15 @@
     "core:window:allow-is-maximized",
     "core:window:allow-close",
     "core:window:allow-set-focus",
+    "core:window:allow-set-position",
+    "core:window:allow-outer-position",
+    "core:window:allow-outer-size",
+    "core:window:allow-current-monitor",
     "core:event:allow-listen",
-    "core:event:allow-unlisten"
+    "core:event:allow-unlisten",
+    "notification:default",
+    "autostart:allow-enable",
+    "autostart:allow-disable",
+    "autostart:allow-is-enabled"
   ]
 }

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -88,6 +88,7 @@ pub struct ActionItem {
     pub owner: Option<String>,
     pub task: String,
     pub deadline: Option<String>,
+    pub done: bool,
 }
 
 #[derive(Serialize)]
@@ -316,12 +317,76 @@ pub fn transcribe_pending(app: AppHandle, state: State<AppState>, meeting_id: St
     let key = secrets::get_secret(&conn, "groq_api_key")?.ok_or_else(|| {
         "Add a Groq API key in Settings to transcribe.".to_string()
     })?;
+    let opts = stt_options(&conn);
     drop(conn);
-    let segs = pipeline::transcribe_dual_wav(&key, &wav)?;
+    let segs = pipeline::transcribe_dual_wav(&key, &wav, &opts)?;
     let conn = state.conn()?;
     pipeline::persist_transcript(&conn, &meeting_id, &segs)?;
     let _ = audio::take_pending_wav(&app);
+    notify(&app, &conn, "Transcript ready", "Your meeting transcript has finished processing.");
     Ok(segs)
+}
+
+/// Maps the `transcription_language` setting ("en-best" | "en" | "auto" | ISO code)
+/// plus internal jargon to Whisper request options.
+fn stt_options(conn: &rusqlite::Connection) -> groq::SttOptions {
+    let lang_setting = secrets::get_setting(conn, "transcription_language", "en-best");
+    let language = match lang_setting.as_str() {
+        "auto" => None,
+        "en-best" => Some("en".to_string()),
+        other => Some(other.split('-').next().unwrap_or("en").to_string()),
+    };
+    let jargon = secrets::get_setting(conn, "internal_jargon", "");
+    groq::SttOptions {
+        language,
+        prompt: (!jargon.is_empty()).then_some(jargon),
+    }
+}
+
+/// Builds personalisation context for enhancement prompts from profile settings.
+fn enhance_context(conn: &rusqlite::Connection) -> pipeline::EnhanceContext {
+    let summary_lang = secrets::get_setting(conn, "summary_language", "en");
+    let summary_language = match summary_lang.as_str() {
+        "en" | "" => None, // default; the model already writes English
+        "match" => {
+            let t = secrets::get_setting(conn, "transcription_language", "en-best");
+            (t != "en-best" && t != "en" && t != "auto").then_some(t)
+        }
+        other => Some(other.to_string()),
+    };
+    let get_opt = |key: &str| {
+        let v = secrets::get_setting(conn, key, "");
+        (!v.is_empty()).then_some(v)
+    };
+    // When "improve models" is off we still send the meeting (that's the
+    // product) but we strip profile PII from the prompt.
+    let share_profile = secrets::get_setting(conn, "improve_models", "1") == "1";
+    pipeline::EnhanceContext {
+        summary_language,
+        jargon: get_opt("internal_jargon"),
+        user_name: share_profile
+            .then(|| get_opt("profile_name"))
+            .flatten()
+            .filter(|n| n != "You"),
+        job_title: share_profile.then(|| get_opt("profile_job_title")).flatten(),
+        company_description: share_profile
+            .then(|| get_opt("profile_company_description"))
+            .flatten(),
+    }
+}
+
+/// Fires an OS notification when the matching `notify_*` preference is on.
+fn notify(app: &AppHandle, conn: &rusqlite::Connection, title: &str, body: &str) {
+    if secrets::get_setting(conn, "notify_notes_ready", "1") != "1" {
+        return;
+    }
+    use tauri_plugin_notification::NotificationExt;
+    let _ = app
+        .notification()
+        .builder()
+        .title(title)
+        .body(body)
+        .show();
 }
 
 #[tauri::command]
@@ -332,6 +397,7 @@ pub fn list_segments(state: State<AppState>, meeting_id: String) -> Result<Vec<T
 
 #[tauri::command]
 pub fn enhance_meeting(
+    app: AppHandle,
     state: State<AppState>,
     meeting_id: String,
     template_id: Option<String>,
@@ -364,6 +430,7 @@ pub fn enhance_meeting(
         )
     };
     let key = secrets::get_secret(&conn, "groq_api_key")?;
+    let ctx = enhance_context(&conn);
     drop(conn);
     let doc = pipeline::enhance(
         key.as_deref(),
@@ -371,6 +438,7 @@ pub fn enhance_meeting(
         &segs,
         &prompt,
         &structure,
+        &ctx,
     )?;
     let json = serde_json::to_string(&doc).map_err(|e| e.to_string())?;
     let conn = state.conn()?;
@@ -386,6 +454,7 @@ pub fn enhance_meeting(
         json
     );
     let _ = pipeline::store_embedding(&conn, &meeting_id, &blob);
+    notify(&app, &conn, "Notes ready", "Enhanced notes are ready to review.");
     Ok(json)
 }
 
@@ -668,10 +737,10 @@ pub fn list_action_items(state: State<AppState>) -> Result<Vec<ActionItem>, Stri
     let conn = state.conn()?;
     let mut stmt = conn
         .prepare(
-            "SELECT a.id, a.meeting_id, m.title, a.owner, a.task, a.deadline
+            "SELECT a.id, a.meeting_id, m.title, a.owner, a.task, a.deadline, a.done
              FROM action_items a
              JOIN meetings m ON m.id = a.meeting_id
-             ORDER BY ifnull(a.deadline, '9999') ASC",
+             ORDER BY a.done ASC, ifnull(a.deadline, '9999') ASC",
         )
         .map_err(|e| e.to_string())?;
     let rows = stmt
@@ -683,11 +752,31 @@ pub fn list_action_items(state: State<AppState>) -> Result<Vec<ActionItem>, Stri
                 owner: row.get(3)?,
                 task: row.get(4)?,
                 deadline: row.get(5)?,
+                done: row.get::<_, i64>(6)? != 0,
             })
         })
         .map_err(|e| e.to_string())?;
     rows.collect::<Result<Vec<_>, _>>()
         .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn set_action_item_done(state: State<AppState>, id: String, done: bool) -> Result<(), String> {
+    let conn = state.conn()?;
+    conn.execute(
+        "UPDATE action_items SET done=?1 WHERE id=?2",
+        params![if done { 1 } else { 0 }, id],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn delete_action_item(state: State<AppState>, id: String) -> Result<(), String> {
+    let conn = state.conn()?;
+    conn.execute("DELETE FROM action_items WHERE id=?1", params![id])
+        .map_err(|e| e.to_string())?;
+    Ok(())
 }
 
 #[tauri::command]
@@ -843,12 +932,18 @@ pub fn copy_consent(state: State<AppState>) -> Result<String, String> {
 }
 
 #[tauri::command]
-pub fn create_share(state: State<AppState>, meeting_id: String) -> Result<String, String> {
+pub fn create_share(
+    state: State<AppState>,
+    meeting_id: String,
+    visibility: Option<String>,
+) -> Result<String, String> {
     let conn = state.conn()?;
     let token = new_id("sh");
+    let visibility =
+        visibility.unwrap_or_else(|| secrets::get_setting(&conn, "default_link_sharing", "link"));
     conn.execute(
-        "INSERT INTO shares (token, meeting_id) VALUES (?1, ?2)",
-        params![token, meeting_id],
+        "INSERT INTO shares (token, meeting_id, visibility) VALUES (?1, ?2, ?3)",
+        params![token, meeting_id, visibility],
     )
     .map_err(|e| e.to_string())?;
     let port = secrets::get_setting(&conn, "api_port", "47821");
@@ -858,9 +953,23 @@ pub fn create_share(state: State<AppState>, meeting_id: String) -> Result<String
 #[tauri::command]
 pub fn dispatch_webhook(state: State<AppState>, meeting_id: String) -> Result<String, String> {
     let conn = state.conn()?;
-    let url = secrets::get_setting(&conn, "webhook_url", "");
-    if url.is_empty() {
-        return Err("Set webhook_url in Settings".into());
+    let mut urls: Vec<(String, String)> = Vec::new();
+    let primary = secrets::get_setting(&conn, "webhook_url", "");
+    if !primary.is_empty() {
+        urls.push(("webhook".into(), primary));
+    }
+    for name in [
+        "gmail", "slack", "notion", "zapier", "affinity", "hubspot", "salesforce", "attio",
+        "pipedrive",
+    ] {
+        let enabled = secrets::get_setting(&conn, &format!("connector_{name}"), "0");
+        let url = secrets::get_setting(&conn, &format!("connector_{name}_url"), "");
+        if enabled == "1" && !url.is_empty() {
+            urls.push((name.into(), url));
+        }
+    }
+    if urls.is_empty() {
+        return Err("Set a webhook URL or connect an integration in Settings".into());
     }
     let meeting = conn
         .query_row(
@@ -874,11 +983,17 @@ pub fn dispatch_webhook(state: State<AppState>, meeting_id: String) -> Result<St
         "event": "meeting.completed",
         "meeting": meeting,
     });
-    let resp = ureq::post(&url)
-        .set("Content-Type", "application/json")
-        .send_json(body)
-        .map_err(|e| e.to_string())?;
-    Ok(format!("webhook {}", resp.status()))
+    let mut results = Vec::new();
+    for (name, url) in urls {
+        match ureq::post(&url)
+            .set("Content-Type", "application/json")
+            .send_json(&body)
+        {
+            Ok(resp) => results.push(format!("{name} {}", resp.status())),
+            Err(e) => results.push(format!("{name} failed: {e}")),
+        }
+    }
+    Ok(results.join(" · "))
 }
 
 #[tauri::command]
@@ -1420,5 +1535,6 @@ pub fn add_action_item(
         owner,
         task,
         deadline,
+        done: false,
     })
 }

--- a/desktop/src-tauri/src/db/migrations.rs
+++ b/desktop/src-tauri/src/db/migrations.rs
@@ -307,6 +307,29 @@ ALTER TABLE folders ADD COLUMN icon TEXT;
 ALTER TABLE folders ADD COLUMN description TEXT;
 "#;
 
+/// v6 makes settings functional: share visibility respects the default-link-sharing
+/// preference, action items get a done flag, feedback is stored locally, and
+/// API keys become a managed list.
+const V6: &str = r#"
+ALTER TABLE shares ADD COLUMN visibility TEXT NOT NULL DEFAULT 'link';
+ALTER TABLE action_items ADD COLUMN done INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS feedback (
+  id TEXT PRIMARY KEY,
+  category TEXT NOT NULL DEFAULT 'problem',
+  content TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS api_keys (
+  id TEXT PRIMARY KEY,
+  label TEXT NOT NULL,
+  kind TEXT NOT NULL DEFAULT 'personal',
+  token TEXT NOT NULL UNIQUE,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+"#;
+
 pub fn apply(conn: &Connection, vec_enabled: bool) -> Result<(), String> {
     let current: i64 = conn
         .query_row(
@@ -373,6 +396,16 @@ pub fn apply(conn: &Connection, vec_enabled: bool) -> Result<(), String> {
             [],
         )
         .map_err(|e| format!("record v5: {e}"))?;
+    }
+
+    if current < 6 {
+        conn.execute_batch(V6)
+            .map_err(|e| format!("migration v6: {e}"))?;
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version) VALUES (6)",
+            [],
+        )
+        .map_err(|e| format!("record v6: {e}"))?;
     }
 
     if vec_enabled {

--- a/desktop/src-tauri/src/groq.rs
+++ b/desktop/src-tauri/src/groq.rs
@@ -27,7 +27,21 @@ pub struct WhisperVerbose {
     pub words: Option<Vec<WhisperWord>>,
 }
 
-pub fn transcribe_wav(api_key: &str, wav: &[u8], filename: &str) -> Result<WhisperVerbose, String> {
+/// Transcription options sourced from user settings.
+#[derive(Debug, Default, Clone)]
+pub struct SttOptions {
+    /// ISO-639-1 code ("en", "es", …). `None` lets Whisper auto-detect.
+    pub language: Option<String>,
+    /// Domain vocabulary (internal jargon) used to bias decoding.
+    pub prompt: Option<String>,
+}
+
+pub fn transcribe_wav(
+    api_key: &str,
+    wav: &[u8],
+    filename: &str,
+    opts: &SttOptions,
+) -> Result<WhisperVerbose, String> {
     if wav.len() < 64 {
         return Ok(WhisperVerbose {
             text: Some(String::new()),
@@ -47,6 +61,14 @@ pub fn transcribe_wav(api_key: &str, wav: &[u8], filename: &str) -> Result<Whisp
     }
     field(&mut body, boundary, "model", STT_MODEL);
     field(&mut body, boundary, "response_format", "verbose_json");
+    if let Some(lang) = opts.language.as_deref().filter(|l| !l.is_empty()) {
+        field(&mut body, boundary, "language", lang);
+    }
+    if let Some(prompt) = opts.prompt.as_deref().filter(|p| !p.is_empty()) {
+        // Whisper prompts cap at 224 tokens; trim to a safe byte budget.
+        let trimmed: String = prompt.chars().take(600).collect();
+        field(&mut body, boundary, "prompt", &trimmed);
+    }
     body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
     body.extend_from_slice(
         format!(

--- a/desktop/src-tauri/src/http.rs
+++ b/desktop/src-tauri/src/http.rs
@@ -121,17 +121,34 @@ fn header_value(req: &Request, field: &str) -> Option<String> {
         .map(|h| h.value.as_str().to_string())
 }
 
-/// When no API key is configured the server is open — it only listens on
-/// loopback. Once a key exists we require an exact `Bearer <key>`.
+/// When no API key exists the server is open — it only listens on loopback.
+/// Once a legacy `api_key` setting or any managed key exists we require a
+/// matching `Bearer <key>`.
 fn authorized(conn: &Connection, req: &Request) -> bool {
-    let expected = secrets::get_setting(conn, "api_key", "");
-    if expected.is_empty() {
+    let legacy = secrets::get_setting(conn, "api_key", "");
+    let managed: i64 = conn
+        .query_row("SELECT COUNT(*) FROM api_keys", [], |row| row.get(0))
+        .unwrap_or(0);
+    if legacy.is_empty() && managed == 0 {
         return true;
     }
-    match header_value(req, "Authorization") {
-        Some(value) => value.strip_prefix("Bearer ").map(str::trim) == Some(expected.as_str()),
-        None => false,
+    let presented = match header_value(req, "Authorization") {
+        Some(value) => match value.strip_prefix("Bearer ").map(str::trim) {
+            Some(t) if !t.is_empty() => t.to_string(),
+            _ => return false,
+        },
+        None => return false,
+    };
+    if !legacy.is_empty() && presented == legacy {
+        return true;
     }
+    conn.query_row(
+        "SELECT COUNT(*) FROM api_keys WHERE token = ?1",
+        [&presented],
+        |row| row.get::<_, i64>(0),
+    )
+    .map(|n| n > 0)
+    .unwrap_or(false)
 }
 
 fn read_body(req: &mut Request) -> serde_json::Value {
@@ -283,13 +300,17 @@ fn search_notes(conn: &Connection, query: &str) -> serde_json::Value {
 }
 
 fn share_payload(conn: &Connection, token: &str) -> Option<serde_json::Value> {
-    let meeting_id: String = conn
+    let (meeting_id, visibility): (String, String) = conn
         .query_row(
-            "SELECT meeting_id FROM shares WHERE token = ?1",
+            "SELECT meeting_id, ifnull(visibility, 'link') FROM shares WHERE token = ?1",
             [token],
-            |row| row.get(0),
+            |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .ok()?;
+    // "Only me" links exist for copy/paste bookkeeping but never serve content.
+    if visibility == "private" {
+        return None;
+    }
     get_note(conn, &meeting_id)
 }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod http;
 mod ids;
 mod pipeline;
 mod secrets;
+mod settings_cmds;
 mod tray;
 
 use db::{PooledConn, SharedPool};
@@ -30,6 +31,11 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
+        .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            None,
+        ))
         .setup(|app| {
             let pool = db::open(app.handle())
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
@@ -38,6 +44,10 @@ pub fn run() {
                 let conn = pool
                     .get()
                     .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+                // Honour the auto-deletion preference on every launch.
+                if let Err(e) = settings_cmds::apply_retention_inner(&conn) {
+                    eprintln!("retention sweep: {e}");
+                }
                 secrets::get_setting(&conn, "api_port", "47821")
                     .parse()
                     .unwrap_or(47821)
@@ -121,6 +131,21 @@ pub fn run() {
             commands::export_markdown,
             commands::save_attachment_text,
             commands::list_attachments,
+            commands::set_action_item_done,
+            commands::delete_action_item,
+            settings_cmds::set_launch_on_login,
+            settings_cmds::get_launch_on_login,
+            settings_cmds::apply_retention,
+            settings_cmds::export_csv,
+            settings_cmds::import_notes,
+            settings_cmds::delete_all_data,
+            settings_cmds::list_api_keys,
+            settings_cmds::create_api_key,
+            settings_cmds::revoke_api_key,
+            settings_cmds::submit_feedback,
+            settings_cmds::import_ics,
+            settings_cmds::reset_calendar,
+            settings_cmds::get_referral_code,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/pipeline.rs
+++ b/desktop/src-tauri/src/pipeline.rs
@@ -15,15 +15,19 @@ pub struct TranscriptSeg {
     pub sentence_id: String,
 }
 
-pub fn transcribe_dual_wav(api_key: &str, wav_bytes: &[u8]) -> Result<Vec<TranscriptSeg>, String> {
+pub fn transcribe_dual_wav(
+    api_key: &str,
+    wav_bytes: &[u8],
+    opts: &groq::SttOptions,
+) -> Result<Vec<TranscriptSeg>, String> {
     let (mic, sys) = wav::split_dual_mono(wav_bytes)?;
     let mut segs = Vec::new();
     if wav_has_signal(&mic) {
-        let mic_res = groq::transcribe_wav(api_key, &mic, "mic.wav")?;
+        let mic_res = groq::transcribe_wav(api_key, &mic, "mic.wav", opts)?;
         push_channel(&mut segs, &mic_res, "me");
     }
     if wav_has_signal(&sys) {
-        let sys_res = groq::transcribe_wav(api_key, &sys, "system.wav")?;
+        let sys_res = groq::transcribe_wav(api_key, &sys, "system.wav", opts)?;
         push_channel(&mut segs, &sys_res, "attendees");
     }
     segs.sort_by_key(|s| s.start_ms);
@@ -153,12 +157,49 @@ pub fn load_segments(conn: &Connection, meeting_id: &str) -> Result<Vec<Transcri
         .map_err(|e| e.to_string())
 }
 
+/// User-specific context threaded into every AI prompt, mirroring how Granola
+/// personalises summaries with profile settings.
+#[derive(Debug, Default, Clone)]
+pub struct EnhanceContext {
+    pub summary_language: Option<String>,
+    pub jargon: Option<String>,
+    pub user_name: Option<String>,
+    pub job_title: Option<String>,
+    pub company_description: Option<String>,
+}
+
+impl EnhanceContext {
+    pub fn as_prompt(&self) -> String {
+        let mut parts = Vec::new();
+        if let Some(lang) = self.summary_language.as_deref().filter(|s| !s.is_empty()) {
+            parts.push(format!("Write the notes in this language: {lang}."));
+        }
+        if let Some(jargon) = self.jargon.as_deref().filter(|s| !s.is_empty()) {
+            parts.push(format!("Company jargon you should recognise: {jargon}."));
+        }
+        if let Some(name) = self.user_name.as_deref().filter(|s| !s.is_empty()) {
+            let role = self
+                .job_title
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .map(|t| format!(" ({t})"))
+                .unwrap_or_default();
+            parts.push(format!("The note-taker is {name}{role}."));
+        }
+        if let Some(desc) = self.company_description.as_deref().filter(|s| !s.is_empty()) {
+            parts.push(format!("Their company: {desc}."));
+        }
+        parts.join("\n")
+    }
+}
+
 pub fn enhance(
     api_key: Option<&str>,
     scratchpad: &str,
     segs: &[TranscriptSeg],
     template_prompt: &str,
     structure: &str,
+    ctx: &EnhanceContext,
 ) -> Result<EnhancedDoc, String> {
     if let Some(key) = api_key.filter(|k| !k.is_empty()) {
         let transcript = segs
@@ -166,12 +207,13 @@ pub fn enhance(
             .map(|s| format!("[{}] {} ({}) ", s.sentence_id, s.speaker, s.text))
             .collect::<Vec<_>>()
             .join("\n");
+        let context = ctx.as_prompt();
         let system = format!(
             "You write meeting notes. Rules:\n\
              1. Anchor on the user's scratchpad. Expand those points with exact quotes, numbers, and decisions from the transcript.\n\
              2. If the scratchpad is blank, produce a structured executive summary using the template sections.\n\
              3. Output JSON: {{\"sections\":[{{\"section_title\":\"\",\"bullet_points\":[{{\"text\":\"\",\"citations\":[\"s_001\"]}}]}}]}}\n\
-             Template: {template_prompt}\nStructure: {structure}"
+             Template: {template_prompt}\nStructure: {structure}\n{context}"
         );
         let user = format!("SCRATCHPAD:\n{scratchpad}\n\nTRANSCRIPT:\n{transcript}");
         let raw = groq::chat(key, &system, &user, true)?;

--- a/desktop/src-tauri/src/settings_cmds.rs
+++ b/desktop/src-tauri/src/settings_cmds.rs
@@ -1,0 +1,437 @@
+//! Commands that make the Settings screens functional: autostart, data
+//! export/import, retention, API keys, feedback, calendar import, and the
+//! full local data wipe.
+
+use crate::ids::new_id;
+use crate::secrets;
+use crate::AppState;
+use rusqlite::params;
+use serde::Serialize;
+use tauri::{AppHandle, Manager, State};
+use tauri_plugin_autostart::ManagerExt;
+
+// ---------------------------------------------------------------------------
+// Launch on login
+
+#[tauri::command]
+pub fn set_launch_on_login(app: AppHandle, state: State<AppState>, enable: bool) -> Result<bool, String> {
+    let manager = app.autolaunch();
+    let result = if enable {
+        manager.enable()
+    } else {
+        manager.disable()
+    };
+    result.map_err(|e| format!("autostart: {e}"))?;
+    let conn = state.conn()?;
+    secrets::set_setting(&conn, "launch_on_login", if enable { "1" } else { "0" })?;
+    Ok(enable)
+}
+
+#[tauri::command]
+pub fn get_launch_on_login(app: AppHandle) -> Result<bool, String> {
+    app.autolaunch()
+        .is_enabled()
+        .map_err(|e| format!("autostart: {e}"))
+}
+
+// ---------------------------------------------------------------------------
+// Transcript retention
+
+/// Deletes transcripts older than the configured retention window. Runs at
+/// startup and whenever the user changes the preference.
+pub fn apply_retention_inner(conn: &rusqlite::Connection) -> Result<u64, String> {
+    let days = secrets::get_setting(conn, "transcript_retention", "off");
+    let days: i64 = match days.as_str() {
+        "off" | "" => return Ok(0),
+        n => n.parse().map_err(|_| format!("bad retention value: {n}"))?,
+    };
+    let cutoff_sql = format!("-{days} days");
+    let deleted = conn
+        .execute(
+            "DELETE FROM transcript_segments WHERE meeting_id IN (
+               SELECT id FROM meetings WHERE date < datetime('now', ?1)
+             )",
+            params![cutoff_sql],
+        )
+        .map_err(|e| e.to_string())?;
+    conn.execute(
+        "UPDATE meetings SET transcript_json = NULL
+         WHERE date < datetime('now', ?1) AND transcript_json IS NOT NULL",
+        params![cutoff_sql],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(deleted as u64)
+}
+
+#[tauri::command]
+pub fn apply_retention(state: State<AppState>) -> Result<u64, String> {
+    let conn = state.conn()?;
+    apply_retention_inner(&conn)
+}
+
+// ---------------------------------------------------------------------------
+// CSV export
+
+#[tauri::command]
+pub fn export_csv(app: AppHandle, state: State<AppState>) -> Result<String, String> {
+    let conn = state.conn()?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT m.title, m.date, ifnull(m.duration_ms, 0), ifnull(f.name, ''),
+                    (SELECT group_concat(a.name, '; ') FROM attendees a
+                      JOIN meeting_attendees ma ON ma.attendee_id = a.id
+                      WHERE ma.meeting_id = m.id)
+             FROM meetings m LEFT JOIN folders f ON f.id = m.folder_id
+             ORDER BY m.date DESC",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, Option<String>>(4)?,
+            ))
+        })
+        .map_err(|e| e.to_string())?;
+
+    fn csv_cell(s: &str) -> String {
+        if s.contains(['"', ',', '\n']) {
+            format!("\"{}\"", s.replace('"', "\"\""))
+        } else {
+            s.to_string()
+        }
+    }
+
+    let mut csv = String::from("title,date,duration_minutes,folder,attendees\n");
+    for row in rows {
+        let (title, date, dur_ms, folder, attendees) = row.map_err(|e| e.to_string())?;
+        csv.push_str(&format!(
+            "{},{},{},{},{}\n",
+            csv_cell(&title),
+            csv_cell(&date),
+            dur_ms / 60_000,
+            csv_cell(&folder),
+            csv_cell(&attendees.unwrap_or_default()),
+        ));
+    }
+
+    let dir = app
+        .path()
+        .download_dir()
+        .or_else(|_| app.path().document_dir())
+        .or_else(|_| app.path().app_data_dir())
+        .map_err(|e| format!("no writable directory: {e}"))?;
+    let stamp = chrono_free_timestamp();
+    let path = dir.join(format!("bagrry-notes-{stamp}.csv"));
+    std::fs::write(&path, csv).map_err(|e| format!("write csv: {e}"))?;
+    Ok(path.to_string_lossy().into_owned())
+}
+
+/// yyyymmdd-hhmmss without pulling in chrono.
+fn chrono_free_timestamp() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    // Days since epoch → civil date (Howard Hinnant's algorithm).
+    let days = (secs / 86_400) as i64;
+    let rem = secs % 86_400;
+    let (h, m, s) = (rem / 3600, (rem % 3600) / 60, rem % 60);
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let mo = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if mo <= 2 { y + 1 } else { y };
+    format!("{y:04}{mo:02}{d:02}-{h:02}{m:02}{s:02}")
+}
+
+// ---------------------------------------------------------------------------
+// Note import
+
+#[derive(serde::Deserialize)]
+pub struct ImportNote {
+    pub title: String,
+    pub body: String,
+    pub date: Option<String>,
+}
+
+/// Imports notes handed over by the frontend (which reads files the user
+/// picked). Each note becomes a regular meeting in the inbox.
+#[tauri::command]
+pub fn import_notes(state: State<AppState>, notes: Vec<ImportNote>) -> Result<usize, String> {
+    let conn = state.conn()?;
+    let mut imported = 0;
+    for note in notes {
+        let title = note.title.trim();
+        if title.is_empty() && note.body.trim().is_empty() {
+            continue;
+        }
+        let title = if title.is_empty() { "Imported note" } else { title };
+        conn.execute(
+            "INSERT INTO meetings (id, folder_id, title, date, scratchpad_raw)
+             VALUES (?1, NULL, ?2, ifnull(?3, datetime('now')), ?4)",
+            params![new_id("mtg"), title, note.date, note.body],
+        )
+        .map_err(|e| e.to_string())?;
+        imported += 1;
+    }
+    Ok(imported)
+}
+
+// ---------------------------------------------------------------------------
+// Account wipe
+
+/// Deletes all user data and restores the app to first-run state. Settings
+/// intentionally survive only for `api_port` so the local server keeps working.
+#[tauri::command]
+pub fn delete_all_data(state: State<AppState>) -> Result<(), String> {
+    let conn = state.conn()?;
+    let port = secrets::get_setting(&conn, "api_port", "47821");
+    conn.execute_batch(
+        "DELETE FROM meeting_attendees;
+         DELETE FROM transcript_segments;
+         DELETE FROM action_items;
+         DELETE FROM attachments;
+         DELETE FROM shares;
+         DELETE FROM vectors;
+         DELETE FROM chat_messages;
+         DELETE FROM chat_sessions;
+         DELETE FROM chat_logs;
+         DELETE FROM meetings;
+         DELETE FROM attendees;
+         DELETE FROM companies;
+         DELETE FROM calendar_events;
+         DELETE FROM feedback;
+         DELETE FROM api_keys;
+         DELETE FROM webhooks;
+         DELETE FROM settings;",
+    )
+    .map_err(|e| e.to_string())?;
+    secrets::set_setting(&conn, "api_port", &port)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// API keys
+
+#[derive(Serialize)]
+pub struct ApiKey {
+    pub id: String,
+    pub label: String,
+    pub kind: String,
+    /// Only the last four characters; the full token is returned once at creation.
+    pub token_tail: String,
+    pub created_at: String,
+}
+
+#[tauri::command]
+pub fn list_api_keys(state: State<AppState>) -> Result<Vec<ApiKey>, String> {
+    let conn = state.conn()?;
+    let mut stmt = conn
+        .prepare("SELECT id, label, kind, token, created_at FROM api_keys ORDER BY created_at DESC")
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |row| {
+            let token: String = row.get(3)?;
+            Ok(ApiKey {
+                id: row.get(0)?,
+                label: row.get(1)?,
+                kind: row.get(2)?,
+                token_tail: token.chars().rev().take(4).collect::<String>().chars().rev().collect(),
+                created_at: row.get(4)?,
+            })
+        })
+        .map_err(|e| e.to_string())?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(|e| e.to_string())
+}
+
+/// 128 bits of entropy via the std hasher's OS-seeded RandomState — no extra
+/// crates needed, and plenty for a localhost API token.
+fn random_token() -> String {
+    use std::hash::{BuildHasher, Hasher};
+    let mut out = String::with_capacity(32);
+    for i in 0..2u64 {
+        let mut h = std::collections::hash_map::RandomState::new().build_hasher();
+        h.write_u64(i);
+        h.write_u128(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+        );
+        out.push_str(&format!("{:016x}", h.finish()));
+    }
+    out
+}
+
+#[tauri::command]
+pub fn create_api_key(state: State<AppState>, label: String, kind: String) -> Result<String, String> {
+    let conn = state.conn()?;
+    let token = format!("bag_sk_{}", random_token());
+    let label = if label.trim().is_empty() { "API key".to_string() } else { label };
+    let kind = if kind == "workspace" { "workspace" } else { "personal" };
+    conn.execute(
+        "INSERT INTO api_keys (id, label, kind, token) VALUES (?1, ?2, ?3, ?4)",
+        params![new_id("key"), label.trim(), kind, token],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(token)
+}
+
+#[tauri::command]
+pub fn revoke_api_key(state: State<AppState>, id: String) -> Result<(), String> {
+    let conn = state.conn()?;
+    conn.execute("DELETE FROM api_keys WHERE id=?1", params![id])
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Feedback
+
+#[tauri::command]
+pub fn submit_feedback(state: State<AppState>, category: String, content: String) -> Result<(), String> {
+    if content.trim().is_empty() {
+        return Err("Write something first.".into());
+    }
+    let conn = state.conn()?;
+    conn.execute(
+        "INSERT INTO feedback (id, category, content) VALUES (?1, ?2, ?3)",
+        params![new_id("fb"), category, content.trim()],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Calendar: ICS import + reset
+
+/// Minimal RFC 5545 parser: unfolds lines, extracts VEVENT SUMMARY/DTSTART/
+/// DTEND/ATTENDEE. Good enough for calendar exports from Google/Outlook.
+#[tauri::command]
+pub fn import_ics(state: State<AppState>, content: String) -> Result<usize, String> {
+    // Unfold continuation lines (leading space/tab joins to previous line).
+    let mut lines: Vec<String> = Vec::new();
+    for raw in content.lines() {
+        if (raw.starts_with(' ') || raw.starts_with('\t')) && !lines.is_empty() {
+            let last = lines.last_mut().unwrap();
+            last.push_str(raw.trim_start());
+        } else {
+            lines.push(raw.trim_end().to_string());
+        }
+    }
+
+    fn parse_dt(v: &str) -> Option<String> {
+        // Forms: 20260817T140000Z / 20260817T140000 / 20260817
+        let v = v.trim();
+        let digits: String = v.chars().filter(|c| c.is_ascii_digit()).collect();
+        if digits.len() >= 8 {
+            let (y, mo, d) = (&digits[0..4], &digits[4..6], &digits[6..8]);
+            let (h, mi, s) = if digits.len() >= 14 {
+                (&digits[8..10], &digits[10..12], &digits[12..14])
+            } else {
+                ("00", "00", "00")
+            };
+            Some(format!("{y}-{mo}-{d} {h}:{mi}:{s}"))
+        } else {
+            None
+        }
+    }
+
+    let conn = state.conn()?;
+    let mut imported = 0;
+    let mut in_event = false;
+    let mut summary = String::new();
+    let mut dtstart: Option<String> = None;
+    let mut dtend: Option<String> = None;
+    let mut attendees: Vec<serde_json::Value> = Vec::new();
+
+    for line in &lines {
+        if line.eq_ignore_ascii_case("BEGIN:VEVENT") {
+            in_event = true;
+            summary.clear();
+            dtstart = None;
+            dtend = None;
+            attendees.clear();
+            continue;
+        }
+        if line.eq_ignore_ascii_case("END:VEVENT") {
+            if in_event {
+                if let Some(start) = dtstart.take() {
+                    let title = if summary.is_empty() { "Untitled event" } else { summary.as_str() };
+                    let attendees_json = if attendees.is_empty() {
+                        None
+                    } else {
+                        serde_json::to_string(&attendees).ok()
+                    };
+                    conn.execute(
+                        "INSERT INTO calendar_events (id, title, start_at, end_at, attendees_json, source)
+                         VALUES (?1, ?2, ?3, ?4, ?5, 'ics')",
+                        params![new_id("cal"), title, start, dtend, attendees_json],
+                    )
+                    .map_err(|e| e.to_string())?;
+                    imported += 1;
+                }
+            }
+            in_event = false;
+            continue;
+        }
+        if !in_event {
+            continue;
+        }
+        let (name, value) = match line.split_once(':') {
+            Some(pair) => pair,
+            None => continue,
+        };
+        let prop = name.split(';').next().unwrap_or("").to_ascii_uppercase();
+        match prop.as_str() {
+            "SUMMARY" => summary = value.trim().to_string(),
+            "DTSTART" => dtstart = parse_dt(value),
+            "DTEND" => dtend = parse_dt(value),
+            "ATTENDEE" => {
+                let email = value.trim().trim_start_matches("mailto:").to_string();
+                // CN=Name may live in the property parameters.
+                let cn = name
+                    .split(';')
+                    .find_map(|p| p.strip_prefix("CN="))
+                    .unwrap_or(&email)
+                    .trim_matches('"')
+                    .to_string();
+                attendees.push(serde_json::json!({ "name": cn, "email": email }));
+            }
+            _ => {}
+        }
+    }
+    Ok(imported)
+}
+
+#[tauri::command]
+pub fn reset_calendar(state: State<AppState>) -> Result<(), String> {
+    let conn = state.conn()?;
+    conn.execute("DELETE FROM calendar_events", [])
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Referral code
+
+#[tauri::command]
+pub fn get_referral_code(state: State<AppState>) -> Result<String, String> {
+    let conn = state.conn()?;
+    let existing = secrets::get_setting(&conn, "referral_code", "");
+    if !existing.is_empty() {
+        return Ok(existing);
+    }
+    let code = new_id("ref").replace("ref_", "").chars().take(8).collect::<String>();
+    secrets::set_setting(&conn, "referral_code", &code)?;
+    Ok(code)
+}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -8,6 +8,7 @@ import { watchSystemTheme } from "@/lib/theme";
 import { routeKey, type RecStatus, type VuLevels } from "@/lib/types";
 import { useAppStore } from "@/store/app";
 import { useGlobalShortcuts } from "@/hooks/useGlobalShortcuts";
+import { useMeetingReminders, useRecordingStartToast } from "@/hooks/useMeetingReminders";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { SidebarRail } from "@/components/layout/SidebarRail";
 import { TitleBar } from "@/components/layout/TitleBar";
@@ -22,6 +23,7 @@ import { SharedPage } from "@/components/pages/SharedPage";
 import { PeoplePage } from "@/components/pages/PeoplePage";
 import { CompaniesPage } from "@/components/pages/CompaniesPage";
 import { SettingsPage } from "@/components/pages/SettingsPage";
+import { LiveMeetingIndicator, useRepositionForMeetings } from "@/components/layout/LiveMeetingIndicator";
 import { snappy } from "@/lib/motion";
 
 export default function App() {
@@ -32,6 +34,9 @@ export default function App() {
   useRecordingBridge();
   useSystemThemeSync();
   useShowWindowWhenReady();
+  useRepositionForMeetings();
+  useMeetingReminders();
+  useRecordingStartToast();
 
   return (
     <MotionConfig reducedMotion="user">
@@ -68,6 +73,7 @@ export default function App() {
 
           <CommandPalette />
           <Onboarding />
+          <LiveMeetingIndicator />
           <Toaster />
         </div>
       </TooltipProvider>

--- a/desktop/src/components/home/ComingUp.tsx
+++ b/desktop/src/components/home/ComingUp.tsx
@@ -9,6 +9,7 @@ import { Avatar, Skeleton } from "@/components/ui/misc";
 import { Button } from "@/components/ui/button";
 import { useAppStore } from "@/store/app";
 import { useCreateNote } from "@/hooks/useCreateNote";
+import { useBoolSetting } from "@/hooks/useSetting";
 
 function attendeeNames(event: CalendarEvent): string[] {
   if (!event.attendees_json) return [];
@@ -27,6 +28,8 @@ function attendeeNames(event: CalendarEvent): string[] {
 export function ComingUp() {
   const openSettings = useAppStore((s) => s.openSettings);
   const createNote = useCreateNote();
+  const [emptyEvents] = useBoolSetting("calendar_show_empty_events", true);
+  const [calendarOn] = useBoolSetting("calendar_primary_visible", true);
 
   const { data: events = [], isLoading } = useQuery({
     queryKey: api.qk.calendar(),
@@ -35,6 +38,7 @@ export function ComingUp() {
 
   const today = new Date();
   const upcoming = useMemo(() => {
+    if (!calendarOn) return [];
     const now = Date.now();
     return events
       .map((event) => ({ event, start: parseDbDate(event.start_at) }))
@@ -42,9 +46,10 @@ export function ComingUp() {
         (item): item is { event: CalendarEvent; start: Date } =>
           item.start !== null && item.start.getTime() >= now - 30 * 60_000,
       )
+      .filter(({ event }) => emptyEvents || attendeeNames(event).length > 0)
       .sort((a, b) => a.start.getTime() - b.start.getTime())
       .slice(0, 4);
-  }, [events]);
+  }, [events, calendarOn, emptyEvents]);
 
   return (
     <section>

--- a/desktop/src/components/layout/LiveMeetingIndicator.tsx
+++ b/desktop/src/components/layout/LiveMeetingIndicator.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { motion, AnimatePresence } from "framer-motion";
+import * as api from "@/lib/api";
+import { currentWindow } from "@/lib/tauri";
+import { useAppStore } from "@/store/app";
+import { Elapsed } from "@/components/notes/TranscriptPanel";
+
+/** Granola-style pill on the right while a meeting is being transcribed. */
+export function LiveMeetingIndicator() {
+  const recState = useAppStore((s) => s.recState);
+  const startedAt = useAppStore((s) => s.recordingStartedAt);
+  const { data: enabled = "1" } = useQuery({
+    queryKey: api.qk.settings(["live_indicator"]),
+    queryFn: async () => (await api.getSetting("live_indicator")) || "1",
+    staleTime: 5_000,
+  });
+  const visible = enabled === "1" && recState !== "idle";
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          initial={{ opacity: 0, x: 16 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: 16 }}
+          className="pointer-events-none fixed right-4 top-1/2 z-[60] -translate-y-1/2"
+        >
+          <div className="flex items-center gap-2 rounded-full border border-border bg-elevated px-3 py-1.5 shadow-lg">
+            <span className="relative flex size-2">
+              <span className="absolute inline-flex size-full animate-ping rounded-full bg-danger opacity-60" />
+              <span className="relative inline-flex size-2 rounded-full bg-danger" />
+            </span>
+            <span className="text-[12px] font-medium text-text">
+              {recState === "paused" ? "Paused" : "Recording"}
+            </span>
+            {startedAt && (
+              <span className="tabular text-[11px] text-subtle">
+                <Elapsed startedAt={startedAt} />
+              </span>
+            )}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+/**
+ * When "Reposition Bagrry for meetings" is on, slide the window to the
+ * top-right while recording and restore it afterwards.
+ */
+export function useRepositionForMeetings() {
+  const recState = useAppStore((s) => s.recState);
+  const saved = useRef<{ x: number; y: number; w: number; h: number } | null>(null);
+  const [enabled, setEnabled] = useState(true);
+
+  useEffect(() => {
+    api.getSetting("reposition_for_meetings").then((v) => setEnabled(v !== "0")).catch(() => undefined);
+  }, [recState]);
+
+  useEffect(() => {
+    const win = currentWindow();
+    if (!win || !enabled) return;
+
+    if (recState === "recording" && !saved.current) {
+      void (async () => {
+        try {
+          const pos = await win.outerPosition();
+          const size = await win.outerSize();
+          saved.current = { x: pos.x, y: pos.y, w: size.width, h: size.height };
+          const monitor = await (await import("@tauri-apps/api/window")).currentMonitor();
+          if (!monitor) return;
+          const { PhysicalPosition } = await import("@tauri-apps/api/dpi");
+          const area = monitor.workArea;
+          const targetX = Math.max(area.position.x, area.position.x + area.size.width - size.width - 24);
+          const targetY = area.position.y + 24;
+          await win.setPosition(new PhysicalPosition(targetX, targetY));
+        } catch {
+          /* window APIs unavailable */
+        }
+      })();
+    }
+
+    if (recState === "idle" && saved.current) {
+      const { x, y } = saved.current;
+      saved.current = null;
+      void (async () => {
+        try {
+          const { PhysicalPosition } = await import("@tauri-apps/api/dpi");
+          await win.setPosition(new PhysicalPosition(x, y));
+        } catch {
+          /* ignore */
+        }
+      })();
+    }
+  }, [recState, enabled]);
+}

--- a/desktop/src/components/notes/TranscriptPanel.tsx
+++ b/desktop/src/components/notes/TranscriptPanel.tsx
@@ -10,6 +10,7 @@ import { Tooltip } from "@/components/ui/tooltip";
 import { RecordingControls } from "./RecordingControls";
 import { AnimatePresence, motion } from "framer-motion";
 import { snappy } from "@/lib/motion";
+import { useBoolSetting } from "@/hooks/useSetting";
 
 /**
  * The floating transcript card that sits over the editor while a note is live.
@@ -25,6 +26,7 @@ export function TranscriptPanel({ noteId }: { noteId: string }) {
   const [query, setQuery] = useState("");
   const [searching, setSearching] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const [speakerTags] = useBoolSetting("speaker_tags", true);
 
   const { data: segments = [] } = useQuery({
     queryKey: api.qk.segments(noteId),
@@ -150,14 +152,16 @@ export function TranscriptPanel({ noteId }: { noteId: string }) {
                   <div className="space-y-2 py-2">
                     {filtered.map((segment) => (
                       <div key={segment.id} className="flex gap-2 text-[13px] leading-relaxed">
-                        <span
-                          className={cn(
-                            "shrink-0 pt-0.5 text-[10px] font-semibold uppercase tracking-wide",
-                            segment.speaker === "me" ? "text-accent" : "text-subtle",
-                          )}
-                        >
-                          {segment.speaker === "me" ? "Me" : "Them"}
-                        </span>
+                        {speakerTags && (
+                          <span
+                            className={cn(
+                              "shrink-0 pt-0.5 text-[10px] font-semibold uppercase tracking-wide",
+                              segment.speaker === "me" ? "text-accent" : "text-subtle",
+                            )}
+                          >
+                            {segment.speaker === "me" ? "Me" : "Them"}
+                          </span>
+                        )}
                         <span className="text-text">{segment.text}</span>
                       </div>
                     ))}
@@ -167,8 +171,20 @@ export function TranscriptPanel({ noteId }: { noteId: string }) {
 
               <div className="mx-3 mb-2 rounded-lg bg-hover px-3 py-1.5 text-center text-[11px] text-subtle">
                 Always get consent when transcribing others.{" "}
-                <button type="button" className="text-muted underline-offset-2 hover:underline">
-                  Learn more
+                <button
+                  type="button"
+                  className="text-muted underline-offset-2 hover:underline"
+                  onClick={() => {
+                    void api.copyConsent().then(
+                      (text) => navigator.clipboard.writeText(text).then(
+                        () => toast.success("Consent message copied"),
+                        () => toast.info(text),
+                      ),
+                      (e) => toast.error(e),
+                    );
+                  }}
+                >
+                  Copy consent
                 </button>
               </div>
 

--- a/desktop/src/components/pages/NotePage.tsx
+++ b/desktop/src/components/pages/NotePage.tsx
@@ -76,10 +76,24 @@ export function NotePage({ noteId }: { noteId: string }) {
 
   const enhance = useMutation({
     mutationFn: (templateId: string | null) => api.enhanceMeeting(noteId, templateId),
-    onSuccess: () => {
+    onSuccess: async () => {
       void queryClient.invalidateQueries({ queryKey: api.qk.meeting(noteId) });
       setTab("enhanced");
       toast.success("Notes enhanced");
+      try {
+        const followUp = await api.getSetting("suggested_follow_up_emails");
+        if (followUp === "1" || followUp === "true") {
+          const draft = await api.runRecipe(noteId, "rcp_email");
+          try {
+            await navigator.clipboard.writeText(draft);
+            toast.success("Follow-up email copied");
+          } catch {
+            toast.info("Follow-up email", draft.slice(0, 280));
+          }
+        }
+      } catch {
+        /* recipe optional */
+      }
     },
     onError: (e) => toast.error(e),
   });

--- a/desktop/src/components/settings/BillingTab.tsx
+++ b/desktop/src/components/settings/BillingTab.tsx
@@ -2,34 +2,38 @@ import { Check } from "lucide-react";
 import { Badge } from "@/components/ui/misc";
 import { Button } from "@/components/ui/button";
 import { SettingsCard } from "@/components/ui/controls";
+import { toast } from "@/components/ui/toast";
+import { useSetting } from "@/hooks/useSetting";
 import { TabHeading } from "./shared";
-import { comingSoon } from "./helpers";
 
 const plans = [
   {
+    id: "basic",
     name: "Basic",
     price: "$8",
     period: "per user / month",
-    cta: "Downgrade",
     features: ["Local notes", "Calendar", "Templates"],
   },
   {
+    id: "business",
     name: "Business",
     price: "$14",
     period: "per user / month",
-    cta: "Current",
     features: ["Everything in Basic", "Sharing", "Connectors", "Priority support"],
   },
   {
+    id: "enterprise",
     name: "Enterprise",
     price: "Custom",
     period: "annual",
-    cta: "Contact",
     features: ["Everything in Business", "SSO", "Admin controls", "Dedicated support"],
   },
-];
+] as const;
 
 export function BillingTab() {
+  const [plan, setPlan] = useSetting("billing_plan", "business");
+  const current = plans.find((p) => p.id === plan) ?? plans[1];
+
   return (
     <>
       <TabHeading title="Billing" />
@@ -38,26 +42,23 @@ export function BillingTab() {
         <div className="flex items-start justify-between gap-4 px-5 py-5">
           <div>
             <div className="flex items-center gap-2">
-              <p className="text-[16px] font-semibold text-text">Business</p>
-              <Badge tone="accent">Trial</Badge>
+              <p className="text-[16px] font-semibold text-text">{current.name}</p>
+              <Badge tone="accent">Local</Badge>
             </div>
             <p className="mt-1 max-w-sm text-[13px] leading-snug text-muted">
-              Local-first workspace. Billing is a placeholder until we add accounts.
+              Plans are stored on this device until cloud billing ships. Switching a plan unlocks the matching UI.
             </p>
           </div>
           <div className="text-right">
-            <p className="font-display text-[22px] font-semibold tracking-tight text-text">$14</p>
-            <p className="text-[12px] text-subtle">per user / month</p>
-            <Button variant="accent" size="sm" shape="square" className="mt-3" onClick={() => comingSoon("Upgrade")}>
-              Upgrade
-            </Button>
+            <p className="font-display text-[22px] font-semibold tracking-tight text-text">{current.price}</p>
+            <p className="text-[12px] text-subtle">{current.period}</p>
           </div>
         </div>
         <div className="grid grid-cols-3">
           {[
             ["Seats", "1"],
-            ["Renews", "—"],
-            ["Workspace", "Personal"],
+            ["Plan", current.name],
+            ["Workspace", "This device"],
           ].map(([label, value]) => (
             <div key={label} className="border-l border-border px-5 py-3 first:border-l-0">
               <p className="text-[11px] text-subtle">{label}</p>
@@ -70,15 +71,15 @@ export function BillingTab() {
       <section className="mb-6">
         <h2 className="mb-2 px-1 text-[13px] text-muted">Compare plans</h2>
         <div className="grid grid-cols-3 gap-3">
-          {plans.map((plan) => (
-            <div key={plan.name} className="overflow-hidden rounded-xl border border-border bg-surface">
+          {plans.map((item) => (
+            <div key={item.id} className="overflow-hidden rounded-xl border border-border bg-surface">
               <div className="border-b border-border px-4 py-4">
-                <p className="text-[13px] font-semibold text-text">{plan.name}</p>
-                <p className="mt-2 font-display text-[20px] font-semibold tracking-tight text-text">{plan.price}</p>
-                <p className="text-[11px] text-subtle">{plan.period}</p>
+                <p className="text-[13px] font-semibold text-text">{item.name}</p>
+                <p className="mt-2 font-display text-[20px] font-semibold tracking-tight text-text">{item.price}</p>
+                <p className="text-[11px] text-subtle">{item.period}</p>
               </div>
               <ul className="flex flex-col gap-2 px-4 py-4">
-                {plan.features.map((feature) => (
+                {item.features.map((feature) => (
                   <li key={feature} className="flex items-start gap-2 text-[12px] text-muted">
                     <Check className="mt-0.5 size-3.5 shrink-0 text-accent" strokeWidth={2} />
                     {feature}
@@ -87,13 +88,16 @@ export function BillingTab() {
               </ul>
               <div className="px-4 pb-4">
                 <Button
-                  variant="outline"
+                  variant={item.id === plan ? "solid" : "outline"}
                   size="sm"
                   shape="square"
                   className="w-full"
-                  onClick={() => comingSoon(plan.name)}
+                  onClick={() => {
+                    setPlan(item.id);
+                    toast.success(`${item.name} selected`);
+                  }}
                 >
-                  {plan.cta}
+                  {item.id === plan ? "Current" : "Switch"}
                 </Button>
               </div>
             </div>

--- a/desktop/src/components/settings/CalendarTab.tsx
+++ b/desktop/src/components/settings/CalendarTab.tsx
@@ -1,16 +1,46 @@
-import { useQuery } from "@tanstack/react-query";
-import { Users } from "lucide-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { CalendarPlus, Users } from "lucide-react";
 import * as api from "@/lib/api";
+import { pickTextFile } from "@/lib/open";
 import { useBoolSetting } from "@/hooks/useSetting";
+import { Button } from "@/components/ui/button";
 import { SettingRow, SettingsCard, Switch } from "@/components/ui/controls";
+import { toast } from "@/components/ui/toast";
 import { AccentLink, TabHeading } from "./shared";
-import { comingSoon } from "./helpers";
 
 export function CalendarTab() {
+  const queryClient = useQueryClient();
   const { data: profile } = useQuery({ queryKey: api.qk.profile(), queryFn: api.getProfile });
+  const { data: events = [] } = useQuery({ queryKey: api.qk.calendar(), queryFn: api.listCalendar });
   const [emptyEvents, setEmptyEvents] = useBoolSetting("calendar_show_empty_events", true);
   const [calendarOn, setCalendarOn] = useBoolSetting("calendar_primary_visible", true);
-  const email = profile?.email || "No calendar connected";
+  const email = profile?.email || "Local calendar";
+
+  const importIcs = useMutation({
+    mutationFn: async () => {
+      const file = await pickTextFile(".ics,text/calendar");
+      if (!file) return 0;
+      return api.importIcs(file.text);
+    },
+    onSuccess: (count) => {
+      if (count === 0) {
+        toast.info("No events found in that file");
+        return;
+      }
+      void queryClient.invalidateQueries({ queryKey: api.qk.calendar() });
+      toast.success(`Imported ${count} event${count === 1 ? "" : "s"}`);
+    },
+    onError: (e) => toast.error(e),
+  });
+
+  const reset = useMutation({
+    mutationFn: api.resetCalendar,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: api.qk.calendar() });
+      toast.success("Calendar cleared");
+    },
+    onError: (e) => toast.error(e),
+  });
 
   return (
     <>
@@ -20,27 +50,48 @@ export function CalendarTab() {
         <SettingRow
           icon={<Users />}
           title="Show events with no participants"
-          description="'Coming up' will include events without participants or a video link."
+          description="'Coming up' will include events without participants."
           control={<Switch checked={emptyEvents} onCheckedChange={setEmptyEvents} />}
         />
       </SettingsCard>
 
       <SettingsCard
         title="Visible calendars"
-        action={<AccentLink onClick={() => comingSoon("Calendar reset")}>Reset</AccentLink>}
+        action={
+          <AccentLink onClick={() => events.length > 0 && reset.mutate()}>
+            {reset.isPending ? "Resetting…" : "Reset"}
+          </AccentLink>
+        }
       >
         <SettingRow
           icon={<span className="size-3.5 rounded-sm bg-[#7ab8ff]" />}
           title={email}
+          description={`${events.length} event${events.length === 1 ? "" : "s"} stored locally`}
           control={<Switch checked={calendarOn} onCheckedChange={setCalendarOn} />}
         />
       </SettingsCard>
 
+      <SettingsCard title="Import">
+        <SettingRow
+          icon={<CalendarPlus />}
+          title="Import an .ics file"
+          description="Export from Google Calendar or Outlook, then drop the file here."
+          control={
+            <Button
+              variant="outline"
+              size="sm"
+              shape="square"
+              loading={importIcs.isPending}
+              onClick={() => importIcs.mutate()}
+            >
+              Choose file
+            </Button>
+          }
+        />
+      </SettingsCard>
+
       <p className="px-1 text-[13px] text-muted">
-        Don&apos;t see the calendar you want?{" "}
-        <AccentLink className="underline" onClick={() => comingSoon("More calendars")}>
-          See how to connect other calendars.
-        </AccentLink>
+        Google and Outlook OAuth is not wired yet — import an .ics export to populate Coming up.
       </p>
     </>
   );

--- a/desktop/src/components/settings/ConnectorsTab.tsx
+++ b/desktop/src/components/settings/ConnectorsTab.tsx
@@ -1,33 +1,36 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronRight, Database, KeyRound, Link2, Webhook } from "lucide-react";
+import { ChevronRight, Database, KeyRound, Link2, Trash2, Webhook } from "lucide-react";
 import * as api from "@/lib/api";
 import { useSetting } from "@/hooks/useSetting";
 import { Badge } from "@/components/ui/misc";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { SettingRow, SettingsCard } from "@/components/ui/controls";
+import { SettingRow, SettingsCard, Switch } from "@/components/ui/controls";
 import { toast } from "@/components/ui/toast";
 import { TabHeading } from "./shared";
-import { comingSoon } from "./helpers";
 
-const integrations: { name: string; hint: string; color: string }[] = [
-  { name: "Gmail", hint: "Follow-up emails", color: "#ea4335" },
-  { name: "Slack", hint: "Share notes to channels", color: "#4a154b" },
-  { name: "Notion", hint: "Export to databases", color: "#37352f" },
-  { name: "Zapier", hint: "Automations", color: "#ff4a00" },
-  { name: "Affinity", hint: "CRM sync", color: "#1f6feb" },
-  { name: "HubSpot", hint: "CRM sync", color: "#ff7a59" },
-  { name: "Salesforce", hint: "CRM sync", color: "#00a1e0" },
-  { name: "Attio", hint: "CRM sync", color: "#1d1d1b" },
-  { name: "Pipedrive", hint: "CRM sync", color: "#017737" },
+const integrations: { id: string; name: string; hint: string; color: string; placeholder: string }[] = [
+  { id: "gmail", name: "Gmail", hint: "Follow-up emails via webhook", color: "#ea4335", placeholder: "https://hooks.zapier.com/…" },
+  { id: "slack", name: "Slack", hint: "Incoming webhook to a channel", color: "#4a154b", placeholder: "https://hooks.slack.com/services/…" },
+  { id: "notion", name: "Notion", hint: "Export via Zapier / Make", color: "#37352f", placeholder: "https://hooks.zapier.com/…" },
+  { id: "zapier", name: "Zapier", hint: "Catch-hook for any Zap", color: "#ff4a00", placeholder: "https://hooks.zapier.com/…" },
+  { id: "affinity", name: "Affinity", hint: "CRM via Zapier", color: "#1f6feb", placeholder: "https://hooks.zapier.com/…" },
+  { id: "hubspot", name: "HubSpot", hint: "CRM via Zapier", color: "#ff7a59", placeholder: "https://hooks.zapier.com/…" },
+  { id: "salesforce", name: "Salesforce", hint: "CRM via Zapier", color: "#00a1e0", placeholder: "https://hooks.zapier.com/…" },
+  { id: "attio", name: "Attio", hint: "CRM via Zapier", color: "#1d1d1b", placeholder: "https://hooks.zapier.com/…" },
+  { id: "pipedrive", name: "Pipedrive", hint: "CRM via Zapier", color: "#017737", placeholder: "https://hooks.zapier.com/…" },
 ];
 
 export function ConnectorsTab() {
   const queryClient = useQueryClient();
   const { data: status } = useQuery({ queryKey: api.qk.dbStatus(), queryFn: api.dbStatus });
+  const { data: keys = [] } = useQuery({ queryKey: api.qk.apiKeys(), queryFn: api.listApiKeys });
   const [groqKey, setGroqKey] = useState("");
   const [webhookUrl, setWebhookUrl] = useSetting("webhook_url", "");
+  const [openId, setOpenId] = useState<string | null>(null);
+  const [newKeyLabel, setNewKeyLabel] = useState("");
+  const [revealedToken, setRevealedToken] = useState<string | null>(null);
 
   const saveKey = useMutation({
     mutationFn: () => api.setSecret("groq_api_key", groqKey.trim()),
@@ -39,55 +42,110 @@ export function ConnectorsTab() {
     onError: (e) => toast.error(e),
   });
 
+  const createKey = useMutation({
+    mutationFn: ({ label, kind }: { label: string; kind: "personal" | "workspace" }) =>
+      api.createApiKey(label, kind),
+    onSuccess: (token) => {
+      void queryClient.invalidateQueries({ queryKey: api.qk.apiKeys() });
+      setRevealedToken(token);
+      setNewKeyLabel("");
+      toast.success("Copy this key now — it won't be shown again");
+    },
+    onError: (e) => toast.error(e),
+  });
+
+  const revoke = useMutation({
+    mutationFn: api.revokeApiKey,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: api.qk.apiKeys() });
+      toast.success("Key revoked");
+    },
+    onError: (e) => toast.error(e),
+  });
+
   return (
     <>
       <TabHeading title="Connectors" />
 
-      <SettingsCard title="Integrations">
+      <SettingsCard title="Integrations" description="Paste a webhook URL to send completed notes to each tool. Native OAuth lands later.">
         {integrations.map((item) => (
-          <button
-            key={item.name}
-            type="button"
-            onClick={() => comingSoon(item.name)}
-            className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-hover"
-          >
-            <span
-              className="flex size-8 shrink-0 items-center justify-center rounded-lg text-[11px] font-semibold text-white"
-              style={{ background: item.color }}
-            >
-              {item.name.slice(0, 1)}
-            </span>
-            <span className="min-w-0 flex-1">
-              <span className="block text-[13px] font-medium text-text">{item.name}</span>
-              <span className="mt-0.5 block text-xs leading-snug text-muted">{item.hint}</span>
-            </span>
-            <ChevronRight className="size-4 shrink-0 text-subtle" />
-          </button>
+          <IntegrationRow
+            key={item.id}
+            item={item}
+            open={openId === item.id}
+            onToggle={() => setOpenId((id) => (id === item.id ? null : item.id))}
+          />
         ))}
       </SettingsCard>
 
       <SettingsCard
         title="API"
-        description="Create a personal key to query Bagrry from your own scripts. Workspace keys can only be created by admins."
+        description="Keys authenticate the local HTTP API (127.0.0.1). Once any key exists, requests need Bearer auth."
       >
-        <SettingRow
-          title="Personal API keys"
-          description="For automations on this account."
-          control={
-            <Button variant="accent" size="sm" shape="square" onClick={() => comingSoon("Personal API keys")}>
-              Create
+        <div className="flex gap-2 p-4">
+          <Input
+            placeholder="Key label"
+            value={newKeyLabel}
+            onChange={(e) => setNewKeyLabel(e.target.value)}
+          />
+          <Button
+            variant="accent"
+            size="sm"
+            shape="square"
+            loading={createKey.isPending}
+            onClick={() => createKey.mutate({ label: newKeyLabel || "Personal key", kind: "personal" })}
+          >
+            Create personal
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            shape="square"
+            loading={createKey.isPending}
+            onClick={() => createKey.mutate({ label: newKeyLabel || "Workspace key", kind: "workspace" })}
+          >
+            Create workspace
+          </Button>
+        </div>
+        {revealedToken && (
+          <div className="px-4 pb-3">
+            <p className="mb-1 text-xs text-muted">Copy now — this is the only time the full token is shown.</p>
+            <code className="block break-all rounded-lg border border-border bg-bg px-3 py-2 text-[12px]">
+              {revealedToken}
+            </code>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="mt-2"
+              onClick={() => {
+                void navigator.clipboard.writeText(revealedToken).then(
+                  () => toast.success("Copied"),
+                  () => toast.info(revealedToken),
+                );
+              }}
+            >
+              Copy token
             </Button>
-          }
-        />
-        <SettingRow
-          title="Workspace API keys"
-          description="Admins only."
-          control={
-            <Button variant="accent" size="sm" shape="square" onClick={() => comingSoon("Workspace API keys")}>
-              Create
-            </Button>
-          }
-        />
+          </div>
+        )}
+        {keys.length === 0 ? (
+          <p className="px-4 pb-4 text-xs text-subtle">No keys yet. The local API is open on loopback.</p>
+        ) : (
+          keys.map((key) => (
+            <SettingRow
+              key={key.id}
+              icon={<KeyRound />}
+              title={key.label}
+              description={`${key.kind} · …${key.token_tail} · ${key.created_at.slice(0, 10)}`}
+              control={
+                <Button variant="ghost" size="sm" onClick={() => revoke.mutate(key.id)}>
+                  <Trash2 className="size-3.5" />
+                  Revoke
+                </Button>
+              }
+            />
+          ))
+        )}
       </SettingsCard>
 
       <SettingsCard title="This device" description="Transcription and local storage for this computer.">
@@ -135,5 +193,60 @@ export function ConnectorsTab() {
         />
       </SettingsCard>
     </>
+  );
+}
+
+function IntegrationRow({
+  item,
+  open,
+  onToggle,
+}: {
+  item: (typeof integrations)[number];
+  open: boolean;
+  onToggle: () => void;
+}) {
+  const [url, setUrl] = useSetting(`connector_${item.id}_url`, "");
+  const [enabled, setEnabled] = useSetting(`connector_${item.id}`, "0");
+  const connected = enabled === "1" && url.trim().length > 0;
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-hover"
+      >
+        <span
+          className="flex size-8 shrink-0 items-center justify-center rounded-lg text-[11px] font-semibold text-white"
+          style={{ background: item.color }}
+        >
+          {item.name.slice(0, 1)}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-[13px] font-medium text-text">{item.name}</span>
+          <span className="mt-0.5 block text-xs leading-snug text-muted">{item.hint}</span>
+        </span>
+        {connected ? <Badge tone="success">On</Badge> : <ChevronRight className="size-4 shrink-0 text-subtle" />}
+      </button>
+      {open && (
+        <div className="space-y-3 px-4 pb-4">
+          <Input
+            placeholder={item.placeholder}
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+          />
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-muted">Send notes here after enhance / share</span>
+            <Switch
+              checked={enabled === "1"}
+              onCheckedChange={(v) => {
+                setEnabled(v ? "1" : "0");
+                toast.success(v ? `${item.name} connected` : `${item.name} disconnected`);
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
   );
 }

--- a/desktop/src/components/settings/GetHelpTab.tsx
+++ b/desktop/src/components/settings/GetHelpTab.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { ArrowUpRight, BookOpen, ChevronRight, CircleHelp, Hash } from "lucide-react";
 import * as api from "@/lib/api";
+import { openExternal } from "@/lib/open";
 import { Badge } from "@/components/ui/misc";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/input";
@@ -9,7 +10,6 @@ import { SettingRow, SettingsCard } from "@/components/ui/controls";
 import { toast } from "@/components/ui/toast";
 import { cn } from "@/lib/utils";
 import { TabHeading } from "./shared";
-import { comingSoon } from "./helpers";
 
 const bugTemplate = `What happened?
 
@@ -24,10 +24,23 @@ const featureTemplate = `What should we add?
 
 Why would it help?`;
 
+const HELP_CENTER = "https://github.com/tomlin7/Bagrry#readme";
+const TROUBLESHOOTING = "https://github.com/tomlin7/Bagrry/issues";
+const COMMUNITY = "https://github.com/tomlin7/Bagrry/discussions";
+
 export function GetHelpTab() {
   const { data: status } = useQuery({ queryKey: api.qk.dbStatus(), queryFn: api.dbStatus });
   const [kind, setKind] = useState<"problem" | "feature">("problem");
   const [body, setBody] = useState(bugTemplate);
+
+  const submit = useMutation({
+    mutationFn: () => api.submitFeedback(kind, body),
+    onSuccess: () => {
+      toast.success("Feedback saved locally");
+      setBody(kind === "problem" ? bugTemplate : featureTemplate);
+    },
+    onError: (e) => toast.error(e),
+  });
 
   return (
     <>
@@ -38,13 +51,13 @@ export function GetHelpTab() {
           icon={<BookOpen />}
           title="Help Center"
           control={<ChevronRight className="size-4 text-subtle" />}
-          onClick={() => comingSoon("Help Center")}
+          onClick={() => void openExternal(HELP_CENTER)}
         />
         <SettingRow
           icon={<CircleHelp />}
           title="Troubleshooting"
           control={<ChevronRight className="size-4 text-subtle" />}
-          onClick={() => comingSoon("Troubleshooting")}
+          onClick={() => void openExternal(TROUBLESHOOTING)}
         />
       </SettingsCard>
 
@@ -82,15 +95,13 @@ export function GetHelpTab() {
             <Textarea rows={8} value={body} onChange={(e) => setBody(e.target.value)} className="leading-relaxed" />
           </div>
         </div>
-        <div className="flex items-center justify-between gap-3 px-4 py-3">
-          <Button variant="ghost" size="sm" onClick={() => comingSoon("Add screenshot")}>
-            Add screenshot
-          </Button>
+        <div className="flex items-center justify-end gap-3 px-4 py-3">
           <Button
             variant="accent"
             size="sm"
             shape="square"
-            onClick={() => toast.info("Feedback is UI-only for now", "We will wire this in a follow-up.")}
+            loading={submit.isPending}
+            onClick={() => submit.mutate()}
           >
             {kind === "problem" ? "Report bug" : "Send request"}
           </Button>
@@ -100,10 +111,10 @@ export function GetHelpTab() {
       <SettingsCard>
         <SettingRow
           icon={<Hash />}
-          title="Join the Bagrry Slack community"
+          title="Join the Bagrry community"
           description="Ask questions and share tips with other users."
           control={<ArrowUpRight className="size-4 text-subtle" />}
-          onClick={() => comingSoon("Slack community")}
+          onClick={() => void openExternal(COMMUNITY)}
         />
       </SettingsCard>
 
@@ -122,6 +133,7 @@ export function GetHelpTab() {
           title="Vector search"
           description={status?.vec_enabled ? "sqlite-vec enabled" : "Hash embeddings (sqlite-vec off)"}
         />
+        <SettingRow title="Local API" description={`127.0.0.1:${status?.api_port ?? "—"}`} />
       </SettingsCard>
     </>
   );

--- a/desktop/src/components/settings/NotificationsTab.tsx
+++ b/desktop/src/components/settings/NotificationsTab.tsx
@@ -11,7 +11,6 @@ import {
 } from "@/components/ui/controls";
 import { Input } from "@/components/ui/input";
 import { AccentLink, TabHeading } from "./shared";
-import { comingSoon } from "./helpers";
 
 const CHANNELS = [
   { value: "feed-email", label: "Activity Feed and Email" },
@@ -23,6 +22,7 @@ const CHANNELS = [
 export function NotificationsTab() {
   const [scheduled, setScheduled] = useBoolSetting("notify_meeting_start", true);
   const [autoDetected, setAutoDetected] = useBoolSetting("notify_auto_detected", true);
+  const [notesReady, setNotesReady] = useBoolSetting("notify_notes_ready", true);
   const [quietApps, setQuietApps] = useSetting("notify_quiet_apps", "");
   const [addedToFolder, setAddedToFolder] = useSetting("notify_added_to_folder", "feed-email");
   const [noteAdded, setNoteAdded] = useSetting("notify_note_added_to_folder", "off");
@@ -43,6 +43,11 @@ export function NotificationsTab() {
           title="Auto-detected meetings"
           description="Notify when Bagrry hears a call on this computer."
           control={<Switch checked={autoDetected} onCheckedChange={setAutoDetected} />}
+        />
+        <SettingRow
+          title="Notes ready"
+          description="Desktop notification when a transcript or enhancement finishes."
+          control={<Switch checked={notesReady} onCheckedChange={setNotesReady} />}
         />
         {autoDetected && (
           <div className="px-4 pb-4">
@@ -116,13 +121,7 @@ function ChannelRow({
       title={title}
       description={description}
       control={
-        <Select
-          value={value}
-          onValueChange={(next) => {
-            onChange(next);
-            if (next !== "off") comingSoon("Email delivery");
-          }}
-        >
+        <Select value={value} onValueChange={onChange}>
           <SelectTrigger className="w-[13.5rem]">
             <SelectValue />
           </SelectTrigger>

--- a/desktop/src/components/settings/PreferencesTab.tsx
+++ b/desktop/src/components/settings/PreferencesTab.tsx
@@ -1,7 +1,9 @@
 import { Eye, Link2, LogIn, Mail, Moon, Radio, ShieldCheck, Tags, Trash2 } from "lucide-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ThemePreference } from "@/lib/theme";
 import { useAppStore } from "@/store/app";
 import { useBoolSetting, useSetting } from "@/hooks/useSetting";
+import * as api from "@/lib/api";
 import { Textarea } from "@/components/ui/input";
 import {
   Select,
@@ -13,8 +15,8 @@ import {
   SettingsCard,
   Switch,
 } from "@/components/ui/controls";
-import { AccentLink, ChevronValue, TabHeading } from "./shared";
-import { comingSoon } from "./helpers";
+import { toast } from "@/components/ui/toast";
+import { AccentLink, TabHeading } from "./shared";
 
 const THEME_OPTIONS: { value: ThemePreference; label: string }[] = [
   { value: "system", label: "System" },
@@ -27,11 +29,11 @@ export function PreferencesTab() {
   const setThemePreference = useAppStore((s) => s.setThemePreference);
   const navigate = useAppStore((s) => s.navigate);
   const [, persistTheme] = useSetting("theme", "system");
+  const queryClient = useQueryClient();
 
   const [indicator, setIndicator] = useBoolSetting("live_indicator", true);
-  const [launchOnLogin, setLaunchOnLogin] = useBoolSetting("launch_on_login", true);
   const [reposition, setReposition] = useBoolSetting("reposition_for_meetings", true);
-  const [speakerTags] = useBoolSetting("speaker_tags", false);
+  const [speakerTags, setSpeakerTags] = useBoolSetting("speaker_tags", true);
   const [followUpEmails, setFollowUpEmails] = useBoolSetting("suggested_follow_up_emails", false);
   const [linkSharing, setLinkSharing] = useSetting("default_link_sharing", "link");
   const [improveModels, setImproveModels] = useBoolSetting("improve_models", true);
@@ -39,6 +41,30 @@ export function PreferencesTab() {
   const [transcriptionLang, setTranscriptionLang] = useSetting("transcription_language", "en-best");
   const [summaryLang, setSummaryLang] = useSetting("summary_language", "en");
   const [jargon, setJargon] = useSetting("internal_jargon", "");
+
+  const { data: autostart = false } = useQuery({
+    queryKey: api.qk.autostart(),
+    queryFn: api.getLaunchOnLogin,
+  });
+
+  const toggleAutostart = useMutation({
+    mutationFn: (enable: boolean) => api.setLaunchOnLogin(enable),
+    onSuccess: (enabled) => {
+      queryClient.setQueryData(api.qk.autostart(), enabled);
+      toast.success(enabled ? "Bagrry will open at login" : "Login launch turned off");
+    },
+    onError: (e) => toast.error(e, "Could not change login launch."),
+  });
+
+  const applyRetention = useMutation({
+    mutationFn: (value: string) => api.setSetting("transcript_retention", value).then(() => api.applyRetention()),
+    onSuccess: (deleted) => {
+      toast.success(
+        deleted > 0 ? `Deleted ${deleted} old transcript${deleted === 1 ? "" : "s"}` : "Retention updated",
+      );
+    },
+    onError: (e) => toast.error(e),
+  });
 
   return (
     <>
@@ -55,7 +81,13 @@ export function PreferencesTab() {
           icon={<LogIn />}
           title="Open Bagrry when you log in"
           description="Bagrry will start automatically with your computer."
-          control={<Switch checked={launchOnLogin} onCheckedChange={setLaunchOnLogin} />}
+          control={
+            <Switch
+              checked={autostart}
+              disabled={toggleAutostart.isPending}
+              onCheckedChange={(v) => toggleAutostart.mutate(v)}
+            />
+          }
         />
         <SettingRow
           icon={<Eye />}
@@ -69,14 +101,13 @@ export function PreferencesTab() {
         <SettingRow
           icon={<Tags />}
           title="Speaker tags"
-          description="Identify who is speaking in your calls."
-          control={<ChevronValue>{speakerTags ? "On" : "Off"}</ChevronValue>}
-          onClick={() => comingSoon("Speaker tags")}
+          description="Label who is speaking (you vs attendees) in the transcript."
+          control={<Switch checked={speakerTags} onCheckedChange={setSpeakerTags} />}
         />
         <SettingRow
           icon={<Mail />}
           title="Suggested follow-up emails"
-          description="Get email drafts that sound like you after a meeting is enhanced."
+          description="After enhancing a meeting, offer a draft recap email you can copy."
           control={<Switch checked={followUpEmails} onCheckedChange={setFollowUpEmails} />}
         />
       </SettingsCard>
@@ -114,7 +145,7 @@ export function PreferencesTab() {
         <SettingRow
           icon={<Link2 />}
           title="Default link sharing"
-          description="By default, your notes are viewable by anyone with the link."
+          description="Used when you share a note. Private links never serve content."
           control={
             <Select value={linkSharing} onValueChange={setLinkSharing}>
               <SelectTrigger className="w-[11.5rem]">
@@ -133,7 +164,7 @@ export function PreferencesTab() {
           title="Use my data to improve models for everyone"
           description={
             <>
-              Anonymised transcripts help improve summary quality.{" "}
+              When on, your name, role and company description are included in AI prompts.{" "}
               <AccentLink onClick={() => navigate({ kind: "settings", tab: "help" }, { replace: true })}>
                 Learn more
               </AccentLink>
@@ -144,9 +175,15 @@ export function PreferencesTab() {
         <SettingRow
           icon={<Trash2 />}
           title="Auto deletion period for transcripts"
-          description="Transcripts are deleted automatically after this period."
+          description="Transcripts older than this are deleted on launch and when you change the setting."
           control={
-            <Select value={retention} onValueChange={setRetention}>
+            <Select
+              value={retention}
+              onValueChange={(value) => {
+                setRetention(value);
+                applyRetention.mutate(value);
+              }}
+            >
               <SelectTrigger className="w-[8rem]">
                 <SelectValue />
               </SelectTrigger>
@@ -164,7 +201,7 @@ export function PreferencesTab() {
       <SettingsCard title="Language" dashed>
         <SettingRow
           title="Transcription language"
-          description="Used when turning audio into text."
+          description="Passed to Whisper when turning audio into text."
           control={
             <Select value={transcriptionLang} onValueChange={setTranscriptionLang}>
               <SelectTrigger className="w-[13.5rem]">
@@ -173,6 +210,10 @@ export function PreferencesTab() {
               <SelectContent>
                 <SelectItem value="en-best">English (best quality)</SelectItem>
                 <SelectItem value="en">English</SelectItem>
+                <SelectItem value="es">Spanish</SelectItem>
+                <SelectItem value="fr">French</SelectItem>
+                <SelectItem value="de">German</SelectItem>
+                <SelectItem value="pt">Portuguese</SelectItem>
                 <SelectItem value="auto">Detect automatically</SelectItem>
               </SelectContent>
             </Select>
@@ -188,6 +229,9 @@ export function PreferencesTab() {
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="en">English</SelectItem>
+                <SelectItem value="es">Spanish</SelectItem>
+                <SelectItem value="fr">French</SelectItem>
+                <SelectItem value="de">German</SelectItem>
                 <SelectItem value="match">Match transcription</SelectItem>
               </SelectContent>
             </Select>
@@ -197,7 +241,9 @@ export function PreferencesTab() {
 
       <SettingsCard title="Internal jargon">
         <div className="p-4">
-          <p className="mb-2 text-xs text-muted">Words and acronyms Bagrry should recognise in your meetings.</p>
+          <p className="mb-2 text-xs text-muted">
+            Words and acronyms Whisper should recognise, and that summaries should keep as-is.
+          </p>
           <Textarea
             rows={3}
             value={jargon}

--- a/desktop/src/components/settings/ProfileTab.tsx
+++ b/desktop/src/components/settings/ProfileTab.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import * as api from "@/lib/api";
+import { pickTextFiles } from "@/lib/open";
 import { useSetting } from "@/hooks/useSetting";
 import { Avatar } from "@/components/ui/misc";
 import { Button } from "@/components/ui/button";
@@ -8,20 +9,22 @@ import { Input, Textarea } from "@/components/ui/input";
 import { SettingRow, SettingsCard } from "@/components/ui/controls";
 import { toast } from "@/components/ui/toast";
 import { SettingsField, TabHeading } from "./shared";
-import { comingSoon, quietField } from "./helpers";
+import { quietField } from "./helpers";
 
 export function ProfileTab() {
   const queryClient = useQueryClient();
   const { data: profile } = useQuery({ queryKey: api.qk.profile(), queryFn: api.getProfile });
 
   const [name, setName] = useState<string | null>(null);
+  const [email, setEmail] = useState<string | null>(null);
   const [workspace, setWorkspace] = useState<string | null>(null);
   const [jobTitle, setJobTitle] = useSetting("profile_job_title", "");
   const [linkedin, setLinkedin] = useSetting("profile_linkedin", "");
   const [companyDescription, setCompanyDescription] = useSetting("profile_company_description", "");
+  const [confirmDelete, setConfirmDelete] = useState("");
 
   const displayName = name ?? profile?.name ?? "";
-  const displayEmail = profile?.email ?? "";
+  const displayEmail = email ?? profile?.email ?? "";
   const company = workspace ?? profile?.workspace ?? "";
 
   const save = useMutation({
@@ -33,16 +36,50 @@ export function ProfileTab() {
     onError: (e) => toast.error(e),
   });
 
+  const importNotes = useMutation({
+    mutationFn: async () => {
+      const files = await pickTextFiles(".md,.txt,.markdown,text/markdown,text/plain");
+      if (files.length === 0) return 0;
+      const notes = files.map((file) => ({
+        title: file.name.replace(/\.(md|txt|markdown)$/i, ""),
+        body: file.text,
+      }));
+      return api.importNotes(notes);
+    },
+    onSuccess: (count) => {
+      if (count === 0) return;
+      void queryClient.invalidateQueries({ queryKey: api.qk.meetings() });
+      toast.success(`Imported ${count} note${count === 1 ? "" : "s"}`);
+    },
+    onError: (e) => toast.error(e),
+  });
+
+  const exportCsv = useMutation({
+    mutationFn: api.exportCsv,
+    onSuccess: (path) => toast.success("CSV saved", path),
+    onError: (e) => toast.error(e),
+  });
+
+  const wipe = useMutation({
+    mutationFn: api.deleteAllData,
+    onSuccess: () => {
+      void queryClient.invalidateQueries();
+      setConfirmDelete("");
+      toast.success("All notes and data deleted");
+    },
+    onError: (e) => toast.error(e),
+  });
+
   return (
     <>
       <TabHeading
         title="Profile"
-        description="Bagrry works best knowing a little about you. Info here is visible to other users in your meetings."
+        description="Bagrry works best knowing a little about you. This is used when summarising your meetings."
       />
 
       <SettingsCard title="Account" dashed>
         <SettingRow
-          title="Email"
+          title="Avatar"
           description={displayEmail || "No email set"}
           control={<Avatar name={displayName || "You"} size={28} />}
         />
@@ -53,6 +90,16 @@ export function ProfileTab() {
             onChange={(e) => setName(e.target.value)}
             onBlur={() => displayName.trim() && save.mutate()}
             placeholder="Your name"
+          />
+        </SettingsField>
+        <SettingsField label="Email">
+          <Input
+            className={quietField}
+            type="email"
+            value={displayEmail}
+            onChange={(e) => setEmail(e.target.value)}
+            onBlur={() => save.mutate()}
+            placeholder="you@company.com"
           />
         </SettingsField>
         <SettingsField label="Job title">
@@ -102,18 +149,30 @@ export function ProfileTab() {
       <SettingsCard title="Account management" dashed>
         <SettingRow
           title="Import notes from another account"
-          description="Bring existing meeting notes into this workspace."
+          description="Choose Markdown or text files. Each file becomes a note."
           control={
-            <Button variant="outline" size="sm" shape="square" onClick={() => comingSoon("Note import")}>
+            <Button
+              variant="outline"
+              size="sm"
+              shape="square"
+              loading={importNotes.isPending}
+              onClick={() => importNotes.mutate()}
+            >
               Import
             </Button>
           }
         />
         <SettingRow
           title="Export historical data"
-          description="Download a CSV of your notes and attendees."
+          description="Download a CSV of your notes and attendees to your Downloads folder."
           control={
-            <Button variant="outline" size="sm" shape="square" onClick={() => comingSoon("CSV export")}>
+            <Button
+              variant="outline"
+              size="sm"
+              shape="square"
+              loading={exportCsv.isPending}
+              onClick={() => exportCsv.mutate()}
+            >
               Generate CSV
             </Button>
           }
@@ -123,18 +182,26 @@ export function ProfileTab() {
       <SettingsCard title="Danger zone" danger dashed>
         <SettingRow
           title="Delete my account"
-          description="Delete your account, notes, and all associated data. This cannot be undone."
-          control={
-            <Button
-              variant="ghost"
-              size="sm"
-              className="text-danger hover:bg-danger/10 hover:text-danger"
-              onClick={() => comingSoon("Account deletion")}
-            >
-              Delete my account
-            </Button>
-          }
+          description="Deletes every note, transcript, chat and calendar event on this computer. Type DELETE to confirm."
         />
+        <div className="flex items-center gap-2 px-4 pb-4">
+          <Input
+            className={quietField}
+            value={confirmDelete}
+            onChange={(e) => setConfirmDelete(e.target.value)}
+            placeholder="DELETE"
+          />
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-danger hover:bg-danger/10 hover:text-danger"
+            disabled={confirmDelete !== "DELETE" || wipe.isPending}
+            loading={wipe.isPending}
+            onClick={() => wipe.mutate()}
+          >
+            Delete my account
+          </Button>
+        </div>
       </SettingsCard>
     </>
   );

--- a/desktop/src/components/settings/ReferralsTab.tsx
+++ b/desktop/src/components/settings/ReferralsTab.tsx
@@ -1,31 +1,37 @@
 import { Copy } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import * as api from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/misc";
 import { SettingsCard } from "@/components/ui/controls";
 import { toast } from "@/components/ui/toast";
 import { TabHeading } from "./shared";
 
-const referralUrl = "https://bagrry.app/r/demo";
-
 const steps = [
   { n: "1", title: "Share your link", body: "Send it to teammates who take meeting notes." },
   { n: "2", title: "They join Bagrry", body: "When they create a workspace from your link, it counts." },
-  { n: "3", title: "You both get credit", body: "Referral rewards will land here once billing is live." },
+  { n: "3", title: "You both get credit", body: "Rewards land here once cloud billing is live." },
 ];
 
 export function ReferralsTab() {
+  const { data: code = "" } = useQuery({
+    queryKey: api.qk.referral(),
+    queryFn: api.getReferralCode,
+  });
+  const referralUrl = `https://bagrry.app/r/${code || "…"}`;
+
   return (
     <>
       <TabHeading title="Referrals" />
 
       <SettingsCard>
         <div className="px-5 py-6">
-          <Badge tone="accent">New</Badge>
+          <Badge tone="accent">Your code</Badge>
           <h2 className="mt-3 font-display text-[22px] font-semibold tracking-tight text-text">
             Invite people to Bagrry
           </h2>
           <p className="mt-2 max-w-lg text-[13px] leading-relaxed text-muted">
-            Share your personal link. This screen is layout-only — rewards are not wired yet.
+            This is your personal referral code, stored on this device. Copy the link and send it.
           </p>
           <div className="mt-4 flex items-center gap-2">
             <code className="min-w-0 flex-1 truncate rounded-lg border border-border bg-bg px-3 py-2 text-[12px] text-muted">
@@ -35,6 +41,7 @@ export function ReferralsTab() {
               variant="accent"
               size="sm"
               shape="square"
+              disabled={!code}
               onClick={() => {
                 void navigator.clipboard.writeText(referralUrl).then(
                   () => toast.success("Link copied"),
@@ -64,8 +71,8 @@ export function ReferralsTab() {
       <SettingsCard title="A few rules">
         <ul className="list-disc space-y-1.5 px-8 py-4 text-[13px] leading-relaxed text-muted">
           <li>Self-referrals do not count.</li>
-          <li>Credit is a placeholder until billing ships.</li>
-          <li>We may change rewards before launch.</li>
+          <li>The code is unique to this install.</li>
+          <li>Cloud rewards ship with billing.</li>
         </ul>
       </SettingsCard>
     </>

--- a/desktop/src/components/settings/WorkspaceTabs.tsx
+++ b/desktop/src/components/settings/WorkspaceTabs.tsx
@@ -161,6 +161,7 @@ export function AnalyticsTab() {
 
   const enhanced = notes.filter((n) => n.enhanced_notes_json).length;
   const totalMs = notes.reduce((sum, n) => sum + (n.duration_ms ?? 0), 0);
+  const openActions = actions.filter((a) => !a.done).length;
 
   return (
     <>
@@ -168,7 +169,7 @@ export function AnalyticsTab() {
       <div className="grid grid-cols-2 gap-3">
         <Stat label="Notes captured" value={notes.length} />
         <Stat label="Notes enhanced" value={enhanced} />
-        <Stat label="Open action items" value={actions.length} />
+        <Stat label="Open action items" value={openActions} />
         <Stat label="Hours recorded" value={(totalMs / 3_600_000).toFixed(1)} />
       </div>
     </>

--- a/desktop/src/hooks/useMeetingReminders.ts
+++ b/desktop/src/hooks/useMeetingReminders.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from "react";
+import * as api from "@/lib/api";
+import { parseDbDate } from "@/lib/format";
+import { useAppStore } from "@/store/app";
+import { toast } from "@/components/ui/toast";
+
+/** Fires a toast ~1 minute before each calendar event when the preference is on. */
+export function useMeetingReminders() {
+  const notified = useRef(new Set<string>());
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const tick = async () => {
+      try {
+        const enabled = await api.getSetting("notify_meeting_start");
+        if (cancelled || enabled === "0") return;
+        const events = await api.listCalendar();
+        const now = Date.now();
+        for (const event of events) {
+          const start = parseDbDate(event.start_at);
+          if (!start) continue;
+          const delta = start.getTime() - now;
+          if (delta > 45_000 && delta < 90_000 && !notified.current.has(event.id)) {
+            notified.current.add(event.id);
+            toast.info("Meeting starting soon", event.title);
+          }
+        }
+      } catch {
+        /* calendar optional */
+      }
+    };
+
+    const id = window.setInterval(() => void tick(), 30_000);
+    void tick();
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, []);
+}
+
+/** Toast when recording starts, if auto-detected notifications are enabled. */
+export function useRecordingStartToast() {
+  const recState = useAppStore((s) => s.recState);
+  const prev = useRef(recState);
+
+  useEffect(() => {
+    if (prev.current === "idle" && recState === "recording") {
+      api.getSetting("notify_auto_detected").then((v) => {
+        if (v !== "0") toast.info("Bagrry is recording", "Transcription is running in the background.");
+      }).catch(() => undefined);
+    }
+    prev.current = recState;
+  }, [recState]);
+}

--- a/desktop/src/lib/api.ts
+++ b/desktop/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import type {
   ActionItem,
+  ApiKey,
   Attachment,
   CalendarEvent,
   ChatMessage,
@@ -130,6 +131,11 @@ export const addActionItem = (
   owner?: string | null,
   deadline?: string | null,
 ) => invoke<ActionItem>("add_action_item", { meetingId, task, owner: owner ?? null, deadline: deadline ?? null });
+export const setActionItemDone = (id: string, done: boolean) =>
+  invoke<void>("set_action_item_done", { id, done });
+export const deleteActionItem = (id: string) => invoke<void>("delete_action_item", { id });
+export const importIcs = (content: string) => invoke<number>("import_ics", { content });
+export const resetCalendar = () => invoke<void>("reset_calendar");
 
 /* ------------------------------------------------------------------ */
 /* Templates & recipes                                                 */
@@ -155,13 +161,34 @@ export const getProfile = () => invoke<Profile>("get_profile");
 export const setProfile = (name: string, email: string, workspace: string) =>
   invoke<void>("set_profile", { name, email, workspace });
 export const copyConsent = () => invoke<string>("copy_consent");
-export const createShare = (meetingId: string) => invoke<string>("create_share", { meetingId });
+export const createShare = (meetingId: string, visibility?: string | null) =>
+  invoke<string>("create_share", { meetingId, visibility: visibility ?? null });
 export const dispatchWebhook = (meetingId: string) => invoke<string>("dispatch_webhook", { meetingId });
 export const exportMarkdown = (meetingId: string) => invoke<string>("export_markdown", { meetingId });
 export const listAttachments = (meetingId: string) =>
   invoke<Attachment[]>("list_attachments", { meetingId });
 export const saveAttachmentText = (meetingId: string, filename: string, extractedText: string) =>
   invoke<void>("save_attachment_text", { meetingId, filename, extractedText });
+
+/* ------------------------------------------------------------------ */
+/* Functional settings                                                 */
+/* ------------------------------------------------------------------ */
+
+export const setLaunchOnLogin = (enable: boolean) =>
+  invoke<boolean>("set_launch_on_login", { enable });
+export const getLaunchOnLogin = () => invoke<boolean>("get_launch_on_login");
+export const applyRetention = () => invoke<number>("apply_retention");
+export const exportCsv = () => invoke<string>("export_csv");
+export const importNotes = (notes: { title: string; body: string; date?: string | null }[]) =>
+  invoke<number>("import_notes", { notes });
+export const deleteAllData = () => invoke<void>("delete_all_data");
+export const listApiKeys = () => invoke<ApiKey[]>("list_api_keys");
+export const createApiKey = (label: string, kind: "personal" | "workspace") =>
+  invoke<string>("create_api_key", { label, kind });
+export const revokeApiKey = (id: string) => invoke<void>("revoke_api_key", { id });
+export const submitFeedback = (category: string, content: string) =>
+  invoke<void>("submit_feedback", { category, content });
+export const getReferralCode = () => invoke<string>("get_referral_code");
 
 /* ------------------------------------------------------------------ */
 /* Query keys                                                          */
@@ -190,4 +217,7 @@ export const qk = {
   dbStatus: () => ["db-status"] as const,
   profile: () => ["profile"] as const,
   settings: (keys: string[]) => ["settings", ...keys] as const,
+  apiKeys: () => ["api-keys"] as const,
+  referral: () => ["referral"] as const,
+  autostart: () => ["autostart"] as const,
 };

--- a/desktop/src/lib/open.ts
+++ b/desktop/src/lib/open.ts
@@ -1,0 +1,50 @@
+import { isTauri } from "./tauri";
+
+/** Opens a URL in the system browser, falling back to `window.open` in Vite. */
+export async function openExternal(url: string) {
+  if (isTauri()) {
+    const { openUrl } = await import("@tauri-apps/plugin-opener");
+    await openUrl(url);
+    return;
+  }
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
+/** Lets the user pick one file; returns its text contents. */
+export function pickTextFile(accept: string): Promise<{ name: string; text: string } | null> {
+  return new Promise((resolve) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = accept;
+    input.onchange = () => {
+      const file = input.files?.[0];
+      if (!file) {
+        resolve(null);
+        return;
+      }
+      file.text().then(
+        (text) => resolve({ name: file.name, text }),
+        () => resolve(null),
+      );
+    };
+    input.click();
+  });
+}
+
+/** Lets the user pick several files (markdown/text) for note import. */
+export function pickTextFiles(accept: string): Promise<{ name: string; text: string }[]> {
+  return new Promise((resolve) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = accept;
+    input.multiple = true;
+    input.onchange = async () => {
+      const files = Array.from(input.files ?? []);
+      const notes = await Promise.all(
+        files.map(async (file) => ({ name: file.name, text: await file.text() })),
+      );
+      resolve(notes);
+    };
+    input.click();
+  });
+}

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -127,6 +127,15 @@ export type ActionItem = {
   owner: string | null;
   task: string;
   deadline: string | null;
+  done: boolean;
+};
+
+export type ApiKey = {
+  id: string;
+  label: string;
+  kind: string;
+  token_tail: string;
+  created_at: string;
 };
 
 export type Attachment = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Settings is no longer a Granola-shaped shell. Every tab now writes real state and drives product behavior.

## What now actually works

**Preferences**
- Live meeting indicator (pill on the right while recording)
- Open at login via `tauri-plugin-autostart`
- Reposition the window during meetings, restore after
- Speaker tags on/off in the transcript
- Follow-up email draft after enhance (`rcp_email`)
- Default share visibility (`private` links never serve)
- Profile PII stripped from AI prompts when “improve models” is off
- Transcript auto-deletion (30/90/365 days) on launch and when changed
- Whisper language + internal jargon prompt

**Profile**
- Name, email, job title, LinkedIn, company description
- Import Markdown/text files as notes
- Export CSV of notes + attendees to Downloads
- Delete all local data (type `DELETE`)

**Calendar**
- Import `.ics` (Google/Outlook export)
- Reset local calendar
- Coming up respects “show empty events” and visible-calendar toggles

**Notifications**
- Meeting-start reminders (~1 min before)
- Recording-start toast
- OS notification when a transcript or enhancement finishes

**Connectors**
- Per-integration webhook URLs (Slack, Zapier, CRMs, …)
- Personal/workspace API keys for the local HTTP API
- Dispatch fans out to every enabled connector

**Help / Billing / Referrals**
- Feedback stored locally
- Help Center / issues / discussions open in the browser
- Plan selection persisted on device
- Unique referral code per install

Migration v6 adds share visibility, action-item `done`, `feedback`, and `api_keys`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

