### PR TITLE
Wire recipes, briefs, action items, and people notes

### DIFF
--- a/desktop/src/components/chat/AskBar.tsx
+++ b/desktop/src/components/chat/AskBar.tsx
@@ -26,6 +26,7 @@ export const MODELS = [
 export function AskBar({
   placeholder = "Ask anything",
   onSubmit,
+  onAttach,
   busy,
   autoFocus,
   showModel = true,
@@ -33,6 +34,7 @@ export function AskBar({
 }: {
   placeholder?: string;
   onSubmit: (value: string) => void;
+  onAttach?: (file: { name: string; text: string }) => void;
   busy?: boolean;
   autoFocus?: boolean;
   showModel?: boolean;
@@ -82,6 +84,18 @@ export function AskBar({
             type="button"
             aria-label="Attach a file"
             className="grid size-6 place-items-center rounded-md text-subtle transition-colors hover:bg-hover hover:text-text"
+            onClick={() => {
+              if (!onAttach) return;
+              const input = document.createElement("input");
+              input.type = "file";
+              input.accept = ".md,.txt,.csv,.json,text/plain";
+              input.onchange = () => {
+                const file = input.files?.[0];
+                if (!file) return;
+                void file.text().then((text) => onAttach({ name: file.name, text }));
+              };
+              input.click();
+            }}
           >
             <Paperclip className="size-3.5" />
           </button>

--- a/desktop/src/components/directory/DirectoryPanel.tsx
+++ b/desktop/src/components/directory/DirectoryPanel.tsx
@@ -21,6 +21,7 @@ export function DirectoryPanel({
   rows,
   empty,
   searchPlaceholder,
+  onRowClick,
 }: {
   title: string;
   subjectColumn: string;
@@ -28,6 +29,7 @@ export function DirectoryPanel({
   rows: DirectoryRow[];
   empty: React.ReactNode;
   searchPlaceholder: string;
+  onRowClick?: (id: string) => void;
 }) {
   const [query, setQuery] = useState("");
   const [searchOpen, setSearchOpen] = useState(false);
@@ -109,9 +111,11 @@ export function DirectoryPanel({
         </div>
 
         {visible.map((row) => (
-          <div
+          <button
             key={row.id}
-            className="grid grid-cols-[minmax(0,1fr)_7.5rem_4.5rem] items-center gap-x-3 rounded-lg px-1 py-2.5 transition-colors hover:bg-hover"
+            type="button"
+            onClick={() => onRowClick?.(row.id)}
+            className="grid w-full grid-cols-[minmax(0,1fr)_7.5rem_4.5rem] items-center gap-x-3 rounded-lg px-1 py-2.5 text-left transition-colors hover:bg-hover"
           >
             <div className="flex min-w-0 items-center gap-2.5">
               <Avatar name={row.avatarName} size={28} />
@@ -122,7 +126,7 @@ export function DirectoryPanel({
             </div>
             <div className="text-[13px] text-muted">{row.lastNoteAt ? formatDayLabel(row.lastNoteAt) : "—"}</div>
             <div className="text-[13px] text-muted">{row.noteCount || "—"}</div>
-          </div>
+          </button>
         ))}
 
         {empty}

--- a/desktop/src/components/directory/EntityDialogs.tsx
+++ b/desktop/src/components/directory/EntityDialogs.tsx
@@ -1,0 +1,86 @@
+import { useQuery } from "@tanstack/react-query";
+import * as api from "@/lib/api";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { NoteList } from "@/components/notes/NoteList";
+import { EmptyState, Skeleton } from "@/components/ui/misc";
+
+export function PersonNotesDialog({
+  personId,
+  name,
+  open,
+  onOpenChange,
+}: {
+  personId: string | null;
+  name: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { data: notes = [], isLoading } = useQuery({
+    queryKey: ["meetings-for-person", personId],
+    queryFn: () => api.meetingsForPerson(personId!),
+    enabled: open && Boolean(personId),
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{name}</DialogTitle>
+          <DialogDescription>Notes this person attended.</DialogDescription>
+        </DialogHeader>
+        {isLoading ? (
+          <Skeleton className="h-24 w-full" />
+        ) : notes.length === 0 ? (
+          <EmptyState title="No notes yet" description="They’ll show up here after you add them to a meeting." />
+        ) : (
+          <NoteList
+            notes={notes}
+            emptyState={null}
+            className="px-0"
+          />
+        )}
+        {notes.length > 0 && (
+          <p className="mt-2 text-xs text-subtle">Click a note to open it.</p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function CompanyNotesDialog({
+  companyName,
+  domain,
+  open,
+  onOpenChange,
+}: {
+  companyName: string;
+  domain: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { data: meetings = [], isLoading } = useQuery({
+    queryKey: api.qk.meetings(),
+    queryFn: () => api.listMeetings(),
+    enabled: open,
+  });
+  const needle = (domain || companyName).toLowerCase();
+  const notes = meetings.filter((m) => `${m.title} ${m.scratchpad_raw}`.toLowerCase().includes(needle));
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{companyName}</DialogTitle>
+          <DialogDescription>Notes that mention this company.</DialogDescription>
+        </DialogHeader>
+        {isLoading ? (
+          <Skeleton className="h-24 w-full" />
+        ) : notes.length === 0 ? (
+          <EmptyState title="No matching notes" />
+        ) : (
+          <NoteList notes={notes} emptyState={null} />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/desktop/src/components/home/ActionItemsStrip.tsx
+++ b/desktop/src/components/home/ActionItemsStrip.tsx
@@ -1,0 +1,66 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { CheckSquare } from "lucide-react";
+import * as api from "@/lib/api";
+import { useAppStore } from "@/store/app";
+import { cn } from "@/lib/utils";
+import { toast } from "@/components/ui/toast";
+
+export function ActionItemsStrip() {
+  const openNote = useAppStore((s) => s.openNote);
+  const queryClient = useQueryClient();
+  const { data: items = [] } = useQuery({
+    queryKey: api.qk.actionItems(),
+    queryFn: api.listActionItems,
+  });
+  const open = items.filter((item) => !item.done);
+
+  const toggle = useMutation({
+    mutationFn: ({ id, done }: { id: string; done: boolean }) => api.setActionItemDone(id, done),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: api.qk.actionItems() }),
+    onError: (e) => toast.error(e),
+  });
+
+  if (open.length === 0) return null;
+
+  return (
+    <section className="mt-8">
+      <h2 className="mb-2 flex items-center gap-2 text-[13px] font-semibold text-text">
+        <CheckSquare className="size-4 text-muted" />
+        Action items
+      </h2>
+      <div className="overflow-hidden rounded-xl border border-border bg-surface">
+        {open.slice(0, 6).map((item) => (
+          <div
+            key={item.id}
+            className="flex items-center gap-3 border-b border-border px-3 py-2 last:border-b-0"
+          >
+            <button
+              type="button"
+              aria-label="Mark done"
+              onClick={() => toggle.mutate({ id: item.id, done: true })}
+              className="grid size-4 shrink-0 place-items-center rounded-sm border border-border-strong hover:bg-hover"
+            />
+            <button
+              type="button"
+              onClick={() => openNote(item.meeting_id)}
+              className="min-w-0 flex-1 text-left"
+            >
+              <p className="truncate text-[13px] text-text">{item.task}</p>
+              <p className="truncate text-[11px] text-subtle">
+                {item.meeting_title}
+                {item.owner ? ` · ${item.owner}` : ""}
+                {item.deadline ? ` · ${item.deadline.slice(0, 10)}` : ""}
+              </p>
+            </button>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function ActionCheckbox({ done, className }: { done: boolean; className?: string }) {
+  return (
+    <span className={cn("size-4 rounded-sm border", done ? "bg-accent border-accent" : "border-border-strong", className)} />
+  );
+}

--- a/desktop/src/components/home/ComingUp.tsx
+++ b/desktop/src/components/home/ComingUp.tsx
@@ -7,6 +7,7 @@ import { dayOffset, formatMonth, formatTime, formatWeekday, parseDbDate } from "
 import type { CalendarEvent } from "@/lib/types";
 import { Avatar, Skeleton } from "@/components/ui/misc";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toast";
 import { useAppStore } from "@/store/app";
 import { useCreateNote } from "@/hooks/useCreateNote";
 import { useBoolSetting } from "@/hooks/useSetting";
@@ -106,6 +107,19 @@ export function ComingUp() {
                       onClick={() => createNote.mutate({ title: event.title, record: true })}
                     >
                       Start now
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+                      onClick={() => {
+                        void api.preMeetingBrief(event.attendees_json ?? "[]").then(
+                          (brief) => toast.info("Pre-meeting brief", brief.slice(0, 400)),
+                          (e) => toast.error(e),
+                        );
+                      }}
+                    >
+                      Brief
                     </Button>
                   </motion.div>
                 );

--- a/desktop/src/components/pages/ChatPage.tsx
+++ b/desktop/src/components/pages/ChatPage.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useRef } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { MessageSquare } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { MessageSquare, Trash2 } from "lucide-react";
 import * as api from "@/lib/api";
 import { formatRelative } from "@/lib/format";
 import { useAppStore } from "@/store/app";
 import { useChat } from "@/hooks/useChat";
 import { AskBar, RecipeChips } from "@/components/chat/AskBar";
 import { Skeleton } from "@/components/ui/misc";
+import { toast } from "@/components/ui/toast";
 
 export function ChatPage({ sessionId }: { sessionId: string | null }) {
   return sessionId ? <ChatThread sessionId={sessionId} /> : <ChatLanding />;
@@ -16,6 +17,7 @@ export function ChatPage({ sessionId }: { sessionId: string | null }) {
 
 function ChatLanding() {
   const navigate = useAppStore((s) => s.navigate);
+  const queryClient = useQueryClient();
   const { send, pending } = useChat(null);
 
   const { data: profile } = useQuery({ queryKey: api.qk.profile(), queryFn: api.getProfile });
@@ -44,22 +46,39 @@ function ChatLanding() {
           <section className="mt-8">
             <h2 className="px-1 pb-1 text-[11px] font-semibold text-subtle">Recents</h2>
             {sessions.slice(0, 8).map((session) => (
-              <button
-                key={session.id}
-                type="button"
-                onClick={() => navigate({ kind: "chat", sessionId: session.id })}
-                className="flex w-full items-center gap-3 rounded-lg px-2 py-2 text-left transition-colors hover:bg-hover"
-              >
-                <div className="grid size-7 shrink-0 place-items-center rounded-lg border border-border bg-surface text-subtle">
-                  <MessageSquare className="size-3.5" />
-                </div>
-                <span className="min-w-0 flex-1 truncate text-[13px] text-text">
-                  {session.title || "New chat"}
-                </span>
-                <span className="shrink-0 text-[11px] text-subtle">
-                  {formatRelative(session.updated_at)}
-                </span>
-              </button>
+              <div key={session.id} className="group flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => navigate({ kind: "chat", sessionId: session.id })}
+                  className="flex min-w-0 flex-1 items-center gap-3 rounded-lg px-2 py-2 text-left transition-colors hover:bg-hover"
+                >
+                  <div className="grid size-7 shrink-0 place-items-center rounded-lg border border-border bg-surface text-subtle">
+                    <MessageSquare className="size-3.5" />
+                  </div>
+                  <span className="min-w-0 flex-1 truncate text-[13px] text-text">
+                    {session.title || "New chat"}
+                  </span>
+                  <span className="shrink-0 text-[11px] text-subtle">
+                    {formatRelative(session.updated_at)}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  aria-label="Delete chat"
+                  className="grid size-7 place-items-center rounded-md text-subtle opacity-0 transition-opacity hover:bg-hover hover:text-danger group-hover:opacity-100"
+                  onClick={() => {
+                    void api.deleteChatSession(session.id).then(
+                      () => {
+                        void queryClient.invalidateQueries({ queryKey: api.qk.chatSessions() });
+                        toast.success("Chat deleted");
+                      },
+                      (e) => toast.error(e),
+                    );
+                  }}
+                >
+                  <Trash2 className="size-3.5" />
+                </button>
+              </div>
             ))}
           </section>
         )}

--- a/desktop/src/components/pages/CompaniesPage.tsx
+++ b/desktop/src/components/pages/CompaniesPage.tsx
@@ -4,9 +4,11 @@ import { Building2 } from "lucide-react";
 import * as api from "@/lib/api";
 import { mergeDomainCompanies, mergeSelfIntoPeople } from "@/lib/directory";
 import { DirectoryEmpty, DirectoryFilter, DirectoryPanel } from "@/components/directory/DirectoryPanel";
+import { CompanyNotesDialog } from "@/components/directory/EntityDialogs";
 
 export function CompaniesPage() {
   const [scope, setScope] = useState<"all" | "met">("all");
+  const [selected, setSelected] = useState<{ name: string; domain: string | null } | null>(null);
   const { data: profile } = useQuery({ queryKey: api.qk.profile(), queryFn: api.getProfile });
   const { data: people = [] } = useQuery({ queryKey: api.qk.people(), queryFn: api.listPeople });
   const { data: companies = [] } = useQuery({ queryKey: api.qk.companies(), queryFn: api.listCompanies });
@@ -35,10 +37,15 @@ export function CompaniesPage() {
   }, [companies, meetings, people, profile, scope]);
 
   return (
-    <DirectoryPanel
-      title="Companies"
-      subjectColumn="Company"
-      searchPlaceholder="Search companies"
+    <>
+      <DirectoryPanel
+        title="Companies"
+        subjectColumn="Company"
+        searchPlaceholder="Search companies"
+        onRowClick={(id) => {
+          const company = rows.find((r) => r.id === id);
+          if (company) setSelected({ name: company.title, domain: company.subtitle ?? null });
+        }}
       filters={
         <DirectoryFilter
           variant="pill-link"
@@ -56,6 +63,13 @@ export function CompaniesPage() {
           <DirectoryEmpty icon={<Building2 />}>Companies of people you meet in Bagrry will appear here.</DirectoryEmpty>
         ) : null
       }
-    />
+      />
+      <CompanyNotesDialog
+        companyName={selected?.name ?? ""}
+        domain={selected?.domain ?? null}
+        open={Boolean(selected)}
+        onOpenChange={(open) => !open && setSelected(null)}
+      />
+    </>
   );
 }

--- a/desktop/src/components/pages/HomePage.tsx
+++ b/desktop/src/components/pages/HomePage.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from "@/store/app";
 import { useCreateNote } from "@/hooks/useCreateNote";
 import { useChat } from "@/hooks/useChat";
 import { ComingUp } from "@/components/home/ComingUp";
+import { ActionItemsStrip } from "@/components/home/ActionItemsStrip";
 import { NoteList } from "@/components/notes/NoteList";
 import { AskBar, RecipeChips } from "@/components/chat/AskBar";
 import { Button } from "@/components/ui/button";
@@ -25,6 +26,7 @@ export function HomePage() {
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto w-full max-w-[720px] px-6 pb-40 pt-2">
           <ComingUp />
+          <ActionItemsStrip />
 
           <div className="mt-8">
             <NoteList

--- a/desktop/src/components/pages/NotePage.tsx
+++ b/desktop/src/components/pages/NotePage.tsx
@@ -59,6 +59,8 @@ export function NotePage({ noteId }: { noteId: string }) {
 
   const { data: folders = [] } = useQuery({ queryKey: api.qk.folders(), queryFn: api.listFolders });
   const { data: templates = [] } = useQuery({ queryKey: api.qk.templates(), queryFn: api.listTemplates });
+  const { data: recipes = [] } = useQuery({ queryKey: api.qk.recipes(), queryFn: api.listRecipes });
+  const { data: people = [] } = useQuery({ queryKey: api.qk.people(), queryFn: api.listPeople });
 
   const saveBody = useMutation({
     mutationFn: (html: string) => api.saveScratchpad(noteId, html),
@@ -156,8 +158,48 @@ export function NotePage({ noteId }: { noteId: string }) {
     onError: (e) => toast.error(e),
   });
 
+  const recipe = useMutation({
+    mutationFn: (recipeId: string) => api.runRecipe(noteId, recipeId),
+    onSuccess: async (result, recipeId) => {
+      try {
+        await navigator.clipboard.writeText(result);
+        toast.success("Recipe result copied");
+      } catch {
+        toast.info("Recipe", result.slice(0, 400));
+      }
+      if (recipeId === "rcp_actions") {
+        const lines = result
+          .split("\n")
+          .map((l) => l.replace(/^[-*•\d.\s]+/, "").trim())
+          .filter((l) => l.length > 4);
+        for (const line of lines.slice(0, 8)) {
+          await api.addActionItem(noteId, line).catch(() => undefined);
+        }
+        void queryClient.invalidateQueries({ queryKey: api.qk.actionItems() });
+      }
+    },
+    onError: (e) => toast.error(e),
+  });
+
+  const addAttendee = useMutation({
+    mutationFn: (personId: string) => api.addMeetingAttendee(noteId, personId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: api.qk.attendees(noteId) });
+      void queryClient.invalidateQueries({ queryKey: api.qk.people() });
+      toast.success("Attendee added");
+    },
+    onError: (e) => toast.error(e),
+  });
+
   const ask = useMutation({
-    mutationFn: (question: string) => api.askBagrry(question, null, noteId),
+    mutationFn: async (question: string) => {
+      if (recState !== "idle") {
+        const segs = await api.listSegments(noteId);
+        const live = segs.map((s) => `${s.speaker}: ${s.text}`).join("\n");
+        return api.liveAsk(question, live);
+      }
+      return api.askBagrry(question, null, noteId);
+    },
     onSuccess: (answer) => toast.info("Answer", answer.slice(0, 400)),
     onError: (e) => toast.error(e),
   });
@@ -193,10 +235,32 @@ export function NotePage({ noteId }: { noteId: string }) {
 
           <div className="mt-2 flex flex-wrap items-center gap-1.5">
             <Chip icon={<CalendarDays className="size-3" />} label={formatDayLabel(note.date)} />
-            <Chip
-              icon={<Users className="size-3" />}
-              label={attendees.length > 0 ? attendees.map((a) => a.name).join(", ") : "Me"}
-            />
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className="flex h-6 max-w-[14rem] items-center gap-1 rounded-full border border-border px-2 text-[11px] text-muted transition-colors hover:border-border-strong hover:text-text"
+                >
+                  <Users className="size-3" />
+                  <span className="truncate">
+                    {attendees.length > 0 ? attendees.map((a) => a.name).join(", ") : "Add people"}
+                  </span>
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                <DropdownMenuLabel>Attendees</DropdownMenuLabel>
+                {people
+                  .filter((p) => !attendees.some((a) => a.id === p.id))
+                  .map((person) => (
+                    <DropdownMenuItem key={person.id} onSelect={() => addAttendee.mutate(person.id)}>
+                      {person.name}
+                    </DropdownMenuItem>
+                  ))}
+                {people.filter((p) => !attendees.some((a) => a.id === p.id)).length === 0 && (
+                  <DropdownMenuItem disabled>Everyone’s already on this note</DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
 
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -235,8 +299,10 @@ export function NotePage({ noteId }: { noteId: string }) {
 
             <EnhanceButton
               templates={templates}
-              loading={enhance.isPending}
+              recipes={recipes}
+              loading={enhance.isPending || recipe.isPending}
               onEnhance={(templateId) => enhance.mutate(templateId)}
+              onRecipe={(id) => recipe.mutate(id)}
             />
 
             <DropdownMenu>
@@ -331,10 +397,14 @@ export function NotePage({ noteId }: { noteId: string }) {
               </div>
               <AskBar
                 className="flex-1"
-                placeholder="Ask anything"
+                placeholder={recState !== "idle" ? "Ask about this live meeting" : "Ask anything"}
                 showModel={false}
                 busy={ask.isPending}
                 onSubmit={(value) => ask.mutate(value)}
+                onAttach={async (file) => {
+                  await api.saveAttachmentText(noteId, file.name, file.text);
+                  toast.success(`Attached ${file.name}`);
+                }}
               />
             </motion.div>
           )}
@@ -415,12 +485,16 @@ function TabButton({
 
 function EnhanceButton({
   templates,
+  recipes,
   loading,
   onEnhance,
+  onRecipe,
 }: {
   templates: { id: string; name: string }[];
+  recipes: { id: string; name: string }[];
   loading: boolean;
   onEnhance: (templateId: string | null) => void;
+  onRecipe: (recipeId: string) => void;
 }) {
   return (
     <DropdownMenu>
@@ -440,6 +514,17 @@ function EnhanceButton({
             {template.name}
           </DropdownMenuItem>
         ))}
+        {recipes.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel>Recipes</DropdownMenuLabel>
+            {recipes.map((item) => (
+              <DropdownMenuItem key={item.id} onSelect={() => onRecipe(item.id)}>
+                {item.name}
+              </DropdownMenuItem>
+            ))}
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/desktop/src/components/pages/PeoplePage.tsx
+++ b/desktop/src/components/pages/PeoplePage.tsx
@@ -4,9 +4,11 @@ import { Users } from "lucide-react";
 import * as api from "@/lib/api";
 import { mergeSelfIntoPeople } from "@/lib/directory";
 import { DirectoryEmpty, DirectoryFilter, DirectoryPanel } from "@/components/directory/DirectoryPanel";
+import { PersonNotesDialog } from "@/components/directory/EntityDialogs";
 
 export function PeoplePage() {
   const [scope, setScope] = useState<"everyone" | "met">("everyone");
+  const [selected, setSelected] = useState<{ id: string; name: string } | null>(null);
   const { data: profile } = useQuery({ queryKey: api.qk.profile(), queryFn: api.getProfile });
   const { data: people = [] } = useQuery({ queryKey: api.qk.people(), queryFn: api.listPeople });
   const { data: meetings = [] } = useQuery({ queryKey: api.qk.meetings(), queryFn: () => api.listMeetings() });
@@ -25,26 +27,39 @@ export function PeoplePage() {
   }));
 
   return (
-    <DirectoryPanel
-      title="People"
-      subjectColumn="Person"
-      searchPlaceholder="Search people"
-      filters={
-        <DirectoryFilter
-          value={scope}
-          onChange={(id) => setScope(id as "everyone" | "met")}
-          options={[
-            { id: "everyone", label: "Everyone" },
-            { id: "met", label: "People I met" },
-          ]}
-        />
-      }
-      rows={rows}
-      empty={
-        metCount === 0 ? (
-          <DirectoryEmpty icon={<Users />}>People you meet in Bagrry will appear here.</DirectoryEmpty>
-        ) : null
-      }
-    />
+    <>
+      <DirectoryPanel
+        title="People"
+        subjectColumn="Person"
+        searchPlaceholder="Search people"
+        onRowClick={(id) => {
+          const person = scoped.find((p) => p.id === id);
+          if (person) setSelected({ id: person.id, name: person.name });
+        }}
+        filters={
+          <DirectoryFilter
+            value={scope}
+            onChange={(id) => setScope(id as "everyone" | "met")}
+            options={[
+              { id: "everyone", label: "Everyone" },
+              { id: "met", label: "People I met" },
+            ]}
+          />
+        }
+        rows={rows}
+        empty={
+          metCount === 0 ? (
+            <DirectoryEmpty icon={<Users />}>People you meet in Bagrry will appear here.</DirectoryEmpty>
+          ) : null
+        }
+      />
+      <PersonNotesDialog
+        personId={selected?.id ?? null}
+        name={selected?.name ?? ""}
+        open={Boolean(selected)}
+        onOpenChange={(open) => !open && setSelected(null)}
+      />
+    </>
   );
 }
+

--- a/desktop/src/components/settings/WorkspaceTabs.tsx
+++ b/desktop/src/components/settings/WorkspaceTabs.tsx
@@ -115,9 +115,37 @@ export function MembersTab() {
 }
 
 export function SpacesTab() {
+  const queryClient = useQueryClient();
   const { data: folders = [] } = useQuery({ queryKey: api.qk.folders(), queryFn: api.listFolders });
   const { data: templates = [] } = useQuery({ queryKey: api.qk.templates(), queryFn: api.listTemplates });
   const { data: recipes = [] } = useQuery({ queryKey: api.qk.recipes(), queryFn: api.listRecipes });
+  const [tplName, setTplName] = useState("");
+  const [tplPrompt, setTplPrompt] = useState("");
+  const [rcpName, setRcpName] = useState("");
+  const [rcpPrompt, setRcpPrompt] = useState("");
+
+  const saveTpl = useMutation({
+    mutationFn: () =>
+      api.saveCustomTemplate(tplName.trim(), tplPrompt.trim(), '{"sections":["Summary","Decisions","Next Steps"]}'),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: api.qk.templates() });
+      setTplName("");
+      setTplPrompt("");
+      toast.success("Template saved");
+    },
+    onError: (e) => toast.error(e),
+  });
+
+  const saveRcp = useMutation({
+    mutationFn: () => api.saveCustomRecipe(rcpName.trim(), rcpPrompt.trim()),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: api.qk.recipes() });
+      setRcpName("");
+      setRcpPrompt("");
+      toast.success("Recipe saved");
+    },
+    onError: (e) => toast.error(e),
+  });
 
   return (
     <>
@@ -144,6 +172,35 @@ export function SpacesTab() {
         {recipes.map((recipe) => (
           <SettingRow key={recipe.id} title={recipe.name} description={recipe.prompt_template} />
         ))}
+        <div className="space-y-2 p-4">
+          <Input placeholder="Recipe name" value={rcpName} onChange={(e) => setRcpName(e.target.value)} />
+          <Input placeholder="Prompt" value={rcpPrompt} onChange={(e) => setRcpPrompt(e.target.value)} />
+          <Button
+            variant="solid"
+            size="sm"
+            disabled={!rcpName.trim() || !rcpPrompt.trim()}
+            loading={saveRcp.isPending}
+            onClick={() => saveRcp.mutate()}
+          >
+            Add recipe
+          </Button>
+        </div>
+      </SettingsCard>
+
+      <SettingsCard title="New template">
+        <div className="space-y-2 p-4">
+          <Input placeholder="Template name" value={tplName} onChange={(e) => setTplName(e.target.value)} />
+          <Input placeholder="Prompt" value={tplPrompt} onChange={(e) => setTplPrompt(e.target.value)} />
+          <Button
+            variant="solid"
+            size="sm"
+            disabled={!tplName.trim() || !tplPrompt.trim()}
+            loading={saveTpl.isPending}
+            onClick={() => saveTpl.mutate()}
+          >
+            Add template
+          </Button>
+        </div>
       </SettingsCard>
     </>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacks on #20. This wires the Granola workflows that already existed in Rust but had no UI.

- Click a person or company to see their notes
- Enhance menu runs **recipes**; extracting action items writes rows you can tick on Home
- Add attendees from the people directory
- Attach a text file to a note
- Ask during a live recording uses `live_ask` with the rolling transcript
- Coming up → **Brief** calls `pre_meeting_brief`
- Chat recents can be deleted
- Settings → Spaces can create custom templates and recipes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

