### PR TITLE
Persist Groq chat and Whisper model picker

### DIFF
--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -337,9 +337,20 @@ fn stt_options(conn: &rusqlite::Connection) -> groq::SttOptions {
         other => Some(other.split('-').next().unwrap_or("en").to_string()),
     };
     let jargon = secrets::get_setting(conn, "internal_jargon", "");
+    let model = secrets::get_setting(conn, "stt_model", "whisper-large-v3-turbo");
     groq::SttOptions {
         language,
         prompt: (!jargon.is_empty()).then_some(jargon),
+        model: (!model.trim().is_empty()).then_some(model),
+    }
+}
+
+fn chat_model(conn: &rusqlite::Connection) -> String {
+    let m = secrets::get_setting(conn, "chat_model", "llama-3.3-70b-versatile");
+    if m.trim().is_empty() {
+        "llama-3.3-70b-versatile".into()
+    } else {
+        m
     }
 }
 
@@ -431,6 +442,7 @@ pub fn enhance_meeting(
     };
     let key = secrets::get_secret(&conn, "groq_api_key")?;
     let ctx = enhance_context(&conn);
+    let model = chat_model(&conn);
     drop(conn);
     let doc = pipeline::enhance(
         key.as_deref(),
@@ -439,6 +451,7 @@ pub fn enhance_meeting(
         &prompt,
         &structure,
         &ctx,
+        Some(&model),
     )?;
     let json = serde_json::to_string(&doc).map_err(|e| e.to_string())?;
     let conn = state.conn()?;
@@ -476,6 +489,7 @@ pub fn run_recipe(state: State<AppState>, meeting_id: String, recipe_id: String)
         )
         .map_err(|e| e.to_string())?;
     let key = secrets::get_secret(&conn, "groq_api_key")?;
+    let model = chat_model(&conn);
     drop(conn);
     let user = format!(
         "NOTES:\n{}\n\nENHANCED:\n{}",
@@ -483,7 +497,7 @@ pub fn run_recipe(state: State<AppState>, meeting_id: String, recipe_id: String)
         meeting.enhanced_notes_json.unwrap_or_default()
     );
     if let Some(k) = key.filter(|s| !s.is_empty()) {
-        groq::chat(&k, &recipe, &user, false)
+        groq::chat(&k, &recipe, &user, false, Some(&model))
     } else {
         Ok(format!(
             "{}\n\n---\n{}\n\n{}",
@@ -504,6 +518,7 @@ pub fn reprompt_selection(
     let conn = state.conn()?;
     let segs = pipeline::load_segments(&conn, &meeting_id)?;
     let key = secrets::get_secret(&conn, "groq_api_key")?;
+    let model = chat_model(&conn);
     drop(conn);
     let transcript = segs
         .iter()
@@ -513,7 +528,7 @@ pub fn reprompt_selection(
     let system = "Rewrite only the provided selection. Keep citations if present.";
     let user = format!("INSTRUCTION: {instruction}\n\nSELECTION:\n{selection}\n\nTRANSCRIPT:\n{transcript}");
     if let Some(k) = key.filter(|s| !s.is_empty()) {
-        groq::chat(&k, system, &user, false)
+        groq::chat(&k, system, &user, false, Some(&model))
     } else {
         Ok(format!("{instruction}\n\n{selection}"))
     }
@@ -580,11 +595,12 @@ pub fn ask_bagrry(
         }
     }
     let key = secrets::get_secret(&conn, "groq_api_key")?;
+    let model = chat_model(&conn);
     drop(conn);
     let system = "Answer from the meeting notes. Cite meeting titles. If unknown, say so.";
     let user = format!("QUESTION: {query}\n\nNOTES:\n{context}");
     if let Some(k) = key.filter(|s| !s.is_empty()) {
-        groq::chat(&k, system, &user, false)
+        groq::chat(&k, system, &user, false, Some(&model))
     } else {
         Ok(if context.is_empty() {
             "No matching notes. Try another query or add a Groq key for synthesis.".into()
@@ -598,11 +614,12 @@ pub fn ask_bagrry(
 pub fn live_ask(state: State<AppState>, query: String, live_transcript: String) -> Result<String, String> {
     let conn = state.conn()?;
     let key = secrets::get_secret(&conn, "groq_api_key")?;
+    let model = chat_model(&conn);
     drop(conn);
     let system = "You are an in-meeting copilot. Be brief. Use only the live transcript.";
     let user = format!("LIVE TRANSCRIPT:\n{live_transcript}\n\nQUESTION: {query}");
     if let Some(k) = key.filter(|s| !s.is_empty()) {
-        groq::chat(&k, system, &user, false)
+        groq::chat(&k, system, &user, false, Some(&model))
     } else {
         Ok("Live copilot needs a Groq API key in Settings.".into())
     }
@@ -893,11 +910,12 @@ pub fn pre_meeting_brief(state: State<AppState>, attendees_json: String) -> Resu
         }
     }
     let key = secrets::get_secret(&conn, "groq_api_key")?;
+    let model = chat_model(&conn);
     drop(conn);
     let system = "Write a short pre-meeting brief: past decisions, open action items, notes on attendees.";
     let user = format!("ATTENDEES: {attendees_json}\n\nHISTORY:\n{ctx}");
     if let Some(k) = key.filter(|s| !s.is_empty()) {
-        groq::chat(&k, system, &user, false)
+        groq::chat(&k, system, &user, false, Some(&model))
     } else {
         Ok(ctx.chars().take(2500).collect())
     }

--- a/desktop/src-tauri/src/groq.rs
+++ b/desktop/src-tauri/src/groq.rs
@@ -34,6 +34,8 @@ pub struct SttOptions {
     pub language: Option<String>,
     /// Domain vocabulary (internal jargon) used to bias decoding.
     pub prompt: Option<String>,
+    /// Groq Whisper model id. `None` uses `whisper-large-v3-turbo`.
+    pub model: Option<String>,
 }
 
 pub fn transcribe_wav(
@@ -59,7 +61,12 @@ pub fn transcribe_wav(
         body.extend_from_slice(value.as_bytes());
         body.extend_from_slice(b"\r\n");
     }
-    field(&mut body, boundary, "model", STT_MODEL);
+    let model = opts
+        .model
+        .as_deref()
+        .filter(|m| !m.is_empty())
+        .unwrap_or(STT_MODEL);
+    field(&mut body, boundary, "model", model);
     field(&mut body, boundary, "response_format", "verbose_json");
     if let Some(lang) = opts.language.as_deref().filter(|l| !l.is_empty()) {
         field(&mut body, boundary, "language", lang);
@@ -97,9 +104,18 @@ pub fn transcribe_wav(
     resp.into_json().map_err(|e| format!("stt json: {e}"))
 }
 
-pub fn chat(api_key: &str, system: &str, user: &str, json_mode: bool) -> Result<String, String> {
+pub fn chat(
+    api_key: &str,
+    system: &str,
+    user: &str,
+    json_mode: bool,
+    model: Option<&str>,
+) -> Result<String, String> {
+    let model = model
+        .filter(|m| !m.is_empty())
+        .unwrap_or(CHAT_MODEL);
     let mut body = json!({
-        "model": CHAT_MODEL,
+        "model": model,
         "temperature": 0.2,
         "messages": [
             {"role": "system", "content": system},

--- a/desktop/src-tauri/src/pipeline.rs
+++ b/desktop/src-tauri/src/pipeline.rs
@@ -200,6 +200,7 @@ pub fn enhance(
     template_prompt: &str,
     structure: &str,
     ctx: &EnhanceContext,
+    model: Option<&str>,
 ) -> Result<EnhancedDoc, String> {
     if let Some(key) = api_key.filter(|k| !k.is_empty()) {
         let transcript = segs
@@ -216,7 +217,7 @@ pub fn enhance(
              Template: {template_prompt}\nStructure: {structure}\n{context}"
         );
         let user = format!("SCRATCHPAD:\n{scratchpad}\n\nTRANSCRIPT:\n{transcript}");
-        let raw = groq::chat(key, &system, &user, true)?;
+        let raw = groq::chat(key, &system, &user, true, model)?;
         if let Ok(doc) = serde_json::from_str::<EnhancedDoc>(&raw) {
             return Ok(doc);
         }

--- a/desktop/src/components/chat/AskBar.tsx
+++ b/desktop/src/components/chat/AskBar.tsx
@@ -2,9 +2,11 @@ import { useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowUp, ChevronDown, Grid2x2, Mic, Paperclip, SquareCheck } from "lucide-react";
 import * as api from "@/lib/api";
+import { CHAT_MODELS, DEFAULT_CHAT_MODEL } from "@/lib/models";
 import { cn } from "@/lib/utils";
 import { AutoTextarea } from "@/components/ui/input";
 import { Tooltip } from "@/components/ui/tooltip";
+import { useSetting } from "@/hooks/useSetting";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -13,11 +15,6 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-
-export const MODELS = [
-  { id: "llama-3.3-70b-versatile", label: "Llama 3.3 70B" },
-  { id: "llama-3.1-8b-instant", label: "Llama 3.1 8B" },
-] as const;
 
 /**
  * The "Ask anything" composer. Used inline on space pages and docked to the
@@ -41,7 +38,7 @@ export function AskBar({
   className?: string;
 }) {
   const [value, setValue] = useState("");
-  const [model, setModel] = useState<string>(MODELS[0].id);
+  const [model, setModel] = useSetting("chat_model", DEFAULT_CHAT_MODEL);
   const [focused, setFocused] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -108,16 +105,17 @@ export function AskBar({
                 type="button"
                 className="flex h-6 items-center gap-1 rounded-md px-1.5 text-[11px] text-muted transition-colors hover:bg-hover hover:text-text"
               >
-                {MODELS.find((m) => m.id === model)?.label ?? "Model"}
+                {CHAT_MODELS.find((m) => m.id === model)?.label ?? "Model"}
                 <ChevronDown className="size-3" />
               </button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="start">
+            <DropdownMenuContent align="start" className="min-w-[14rem]">
               <DropdownMenuLabel>Model</DropdownMenuLabel>
               <DropdownMenuRadioGroup value={model} onValueChange={setModel}>
-                {MODELS.map((m) => (
+                {CHAT_MODELS.map((m) => (
                   <DropdownMenuRadioItem key={m.id} value={m.id}>
                     {m.label}
+                    <span className="ml-auto text-[10px] text-muted">{m.hint}</span>
                   </DropdownMenuRadioItem>
                 ))}
               </DropdownMenuRadioGroup>

--- a/desktop/src/components/settings/PreferencesTab.tsx
+++ b/desktop/src/components/settings/PreferencesTab.tsx
@@ -1,4 +1,4 @@
-import { Eye, Link2, LogIn, Mail, Moon, Radio, ShieldCheck, Tags, Trash2 } from "lucide-react";
+import { Cpu, Eye, Link2, LogIn, Mail, Mic, Moon, Radio, ShieldCheck, Tags, Trash2 } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ThemePreference } from "@/lib/theme";
 import { useAppStore } from "@/store/app";
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/controls";
 import { toast } from "@/components/ui/toast";
 import { AccentLink, TabHeading } from "./shared";
+import { CHAT_MODELS, DEFAULT_CHAT_MODEL, DEFAULT_STT_MODEL, STT_MODELS } from "@/lib/models";
 
 const THEME_OPTIONS: { value: ThemePreference; label: string }[] = [
   { value: "system", label: "System" },
@@ -41,6 +42,8 @@ export function PreferencesTab() {
   const [transcriptionLang, setTranscriptionLang] = useSetting("transcription_language", "en-best");
   const [summaryLang, setSummaryLang] = useSetting("summary_language", "en");
   const [jargon, setJargon] = useSetting("internal_jargon", "");
+  const [chatModel, setChatModel] = useSetting("chat_model", DEFAULT_CHAT_MODEL);
+  const [sttModel, setSttModel] = useSetting("stt_model", DEFAULT_STT_MODEL);
 
   const { data: autostart = false } = useQuery({
     queryKey: api.qk.autostart(),
@@ -109,6 +112,47 @@ export function PreferencesTab() {
           title="Suggested follow-up emails"
           description="After enhancing a meeting, offer a draft recap email you can copy."
           control={<Switch checked={followUpEmails} onCheckedChange={setFollowUpEmails} />}
+        />
+      </SettingsCard>
+
+      <SettingsCard title="AI models">
+        <SettingRow
+          icon={<Cpu />}
+          title="Chat model"
+          description="Used for Ask, enhance, recipes, briefs, and live copilot."
+          control={
+            <Select value={chatModel} onValueChange={setChatModel}>
+              <SelectTrigger className="w-[13.5rem]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CHAT_MODELS.map((m) => (
+                  <SelectItem key={m.id} value={m.id}>
+                    {m.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          }
+        />
+        <SettingRow
+          icon={<Mic />}
+          title="Transcription model"
+          description="Whisper variant Groq uses when turning meeting audio into text."
+          control={
+            <Select value={sttModel} onValueChange={setSttModel}>
+              <SelectTrigger className="w-[13.5rem]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {STT_MODELS.map((m) => (
+                  <SelectItem key={m.id} value={m.id}>
+                    {m.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          }
         />
       </SettingsCard>
 

--- a/desktop/src/lib/models.ts
+++ b/desktop/src/lib/models.ts
@@ -1,0 +1,22 @@
+/** Groq model catalogs shown in AskBar and Settings → Preferences. */
+
+export const CHAT_MODELS = [
+  { id: "llama-3.3-70b-versatile", label: "Llama 3.3 70B", hint: "Best quality" },
+  { id: "llama-3.1-8b-instant", label: "Llama 3.1 8B", hint: "Fastest" },
+  { id: "meta-llama/llama-4-scout-17b-16e-instruct", label: "Llama 4 Scout", hint: "Long context" },
+  { id: "meta-llama/llama-4-maverick-17b-128e-instruct", label: "Llama 4 Maverick", hint: "Highest quality" },
+  { id: "openai/gpt-oss-20b", label: "GPT-OSS 20B", hint: "Open weights" },
+  { id: "qwen/qwen3-32b", label: "Qwen 3 32B", hint: "Strong reasoning" },
+] as const;
+
+export const STT_MODELS = [
+  { id: "whisper-large-v3-turbo", label: "Whisper Turbo", hint: "Fast" },
+  { id: "whisper-large-v3", label: "Whisper Large v3", hint: "Best accuracy" },
+  { id: "distil-whisper-large-v3-en", label: "Distil Whisper EN", hint: "English only" },
+] as const;
+
+export const DEFAULT_CHAT_MODEL = CHAT_MODELS[0].id;
+export const DEFAULT_STT_MODEL = STT_MODELS[0].id;
+
+export type ChatModelId = (typeof CHAT_MODELS)[number]["id"];
+export type SttModelId = (typeof STT_MODELS)[number]["id"];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The AskBar model radio was local React state, so every chat/enhance/recipe/brief call still hit the hardcoded Llama 3.3 70B. This wires a real catalog through settings.

### What changed
- `chat_model` and `stt_model` persist in the SQLite settings table
- AskBar dropdown and Settings → Preferences → AI models share the same catalog
- `groq::chat` takes an optional model; enhance, recipes, Ask, live copilot, and briefs pass the selected one
- Whisper transcription uses the selected STT model (`whisper-large-v3-turbo` default, Large v3, Distil EN)

Stacks on #21.

`cargo check` and `tsc --noEmit` both pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

