### PR TITLE
Disk-backed recording, chunked STT, live transcript

### DIFF
--- a/desktop/src-tauri/src/audio/capture.rs
+++ b/desktop/src-tauri/src/audio/capture.rs
@@ -1,4 +1,5 @@
-use super::resample::{push_capped, resample_mono, rms, to_mono_i16};
+use super::resample::{resample_mono, rms, to_mono_i16};
+use super::sink::PcmSink;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::SampleFormat;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
@@ -8,10 +9,10 @@ use std::thread::JoinHandle;
 pub fn start_mic(
     stop: Arc<AtomicBool>,
     paused: Arc<AtomicBool>,
-    pcm: Arc<Mutex<Vec<i16>>>,
+    pcm: Arc<PcmSink>,
     level: Arc<AtomicU32>,
+    last_error: Arc<Mutex<Option<String>>>,
     target_hz: u32,
-    max_seconds: usize,
 ) -> Result<JoinHandle<()>, String> {
     let host = cpal::default_host();
     let device = host
@@ -22,13 +23,19 @@ pub fn start_mic(
         .map_err(|e| format!("mic config: {e}"))?;
     let sample_rate = config.sample_rate().0;
     let channels = config.channels() as usize;
-    let max_samples = target_hz as usize * max_seconds;
     let format = config.sample_format();
     let stream_config = config.into();
     std::thread::Builder::new()
         .name("mic-capture".into())
         .spawn(move || {
-            let err_fn = |e| eprintln!("mic stream error: {e}");
+            let last_error_cb = last_error.clone();
+            let err_fn = move |e| {
+                let msg = format!("mic stream error: {e}");
+                eprintln!("{msg}");
+                if let Ok(mut slot) = last_error_cb.lock() {
+                    *slot = Some(msg);
+                }
+            };
             let stream = match format {
                 SampleFormat::F32 => device.build_input_stream(
                     &stream_config,
@@ -41,16 +48,7 @@ pub fn start_mic(
                             if stop.load(Ordering::Relaxed) {
                                 return;
                             }
-                            ingest_f32(
-                                data,
-                                channels,
-                                sample_rate,
-                                target_hz,
-                                max_samples,
-                                paused.as_ref(),
-                                &pcm,
-                                &level,
-                            );
+                            ingest_f32(data, channels, sample_rate, target_hz, paused.as_ref(), &pcm, &level);
                         }
                     },
                     err_fn,
@@ -67,16 +65,7 @@ pub fn start_mic(
                             if stop.load(Ordering::Relaxed) {
                                 return;
                             }
-                            ingest_i16(
-                                data,
-                                channels,
-                                sample_rate,
-                                target_hz,
-                                max_samples,
-                                paused.as_ref(),
-                                &pcm,
-                                &level,
-                            );
+                            ingest_i16(data, channels, sample_rate, target_hz, paused.as_ref(), &pcm, &level);
                         }
                     },
                     err_fn,
@@ -94,35 +83,38 @@ pub fn start_mic(
                                 return;
                             }
                             let f: Vec<f32> = data.iter().map(|s| *s as f32 / i32::MAX as f32).collect();
-                            ingest_f32(
-                                &f,
-                                channels,
-                                sample_rate,
-                                target_hz,
-                                max_samples,
-                                paused.as_ref(),
-                                &pcm,
-                                &level,
-                            );
+                            ingest_f32(&f, channels, sample_rate, target_hz, paused.as_ref(), &pcm, &level);
                         }
                     },
                     err_fn,
                     None,
                 ),
                 other => {
-                    eprintln!("unsupported mic format: {other}");
+                    let msg = format!("unsupported mic format: {other}");
+                    eprintln!("{msg}");
+                    if let Ok(mut slot) = last_error.lock() {
+                        *slot = Some(msg);
+                    }
                     return;
                 }
             };
             let stream = match stream {
                 Ok(s) => s,
                 Err(e) => {
-                    eprintln!("mic stream: {e}");
+                    let msg = format!("mic stream: {e}");
+                    eprintln!("{msg}");
+                    if let Ok(mut slot) = last_error.lock() {
+                        *slot = Some(msg);
+                    }
                     return;
                 }
             };
             if let Err(e) = stream.play() {
-                eprintln!("mic play: {e}");
+                let msg = format!("mic play: {e}");
+                eprintln!("{msg}");
+                if let Ok(mut slot) = last_error.lock() {
+                    *slot = Some(msg);
+                }
                 return;
             }
             while !stop.load(Ordering::Relaxed) {
@@ -136,24 +128,27 @@ pub fn start_mic(
 pub fn start_loopback(
     stop: Arc<AtomicBool>,
     paused: Arc<AtomicBool>,
-    pcm: Arc<Mutex<Vec<i16>>>,
+    pcm: Arc<PcmSink>,
     level: Arc<AtomicU32>,
+    last_error: Arc<Mutex<Option<String>>>,
     target_hz: u32,
-    max_seconds: usize,
 ) -> (Option<JoinHandle<()>>, bool) {
     #[cfg(windows)]
     {
-        match spawn_wasapi_loopback(stop, paused, pcm, level, target_hz, max_seconds) {
+        match spawn_wasapi_loopback(stop, paused, pcm, level, last_error.clone(), target_hz) {
             Ok(handle) => (Some(handle), true),
             Err(e) => {
                 eprintln!("loopback unavailable: {e}");
+                if let Ok(mut slot) = last_error.lock() {
+                    *slot = Some(format!("System audio unavailable: {e}"));
+                }
                 (None, false)
             }
         }
     }
     #[cfg(not(windows))]
     {
-        let _ = (stop, paused, pcm, level, target_hz, max_seconds);
+        let _ = (stop, paused, pcm, level, last_error, target_hz);
         (None, false)
     }
 }
@@ -163,9 +158,8 @@ fn ingest_f32(
     channels: usize,
     sample_rate: u32,
     target_hz: u32,
-    max_samples: usize,
     paused: &AtomicBool,
-    pcm: &Mutex<Vec<i16>>,
+    pcm: &PcmSink,
     level: &AtomicU32,
 ) {
     let mut mono = Vec::with_capacity(data.len() / channels.max(1));
@@ -177,9 +171,7 @@ fn ingest_f32(
     if paused.load(Ordering::Relaxed) {
         return;
     }
-    if let Ok(mut buf) = pcm.lock() {
-        push_capped(&mut buf, &resampled, max_samples);
-    }
+    pcm.push(&resampled);
 }
 
 fn ingest_i16(
@@ -187,42 +179,35 @@ fn ingest_i16(
     channels: usize,
     sample_rate: u32,
     target_hz: u32,
-    max_seconds_samples: usize,
     paused: &AtomicBool,
-    pcm: &Mutex<Vec<i16>>,
+    pcm: &PcmSink,
     level: &AtomicU32,
 ) {
     let mut as_f = Vec::with_capacity(data.len());
     for s in data {
         as_f.push(*s as f32 / i16::MAX as f32);
     }
-    ingest_f32(
-        &as_f,
-        channels,
-        sample_rate,
-        target_hz,
-        max_seconds_samples,
-        paused,
-        pcm,
-        level,
-    );
+    ingest_f32(&as_f, channels, sample_rate, target_hz, paused, pcm, level);
 }
 
 #[cfg(windows)]
 fn spawn_wasapi_loopback(
     stop: Arc<AtomicBool>,
     paused: Arc<AtomicBool>,
-    pcm: Arc<Mutex<Vec<i16>>>,
+    pcm: Arc<PcmSink>,
     level: Arc<AtomicU32>,
+    last_error: Arc<Mutex<Option<String>>>,
     target_hz: u32,
-    max_seconds: usize,
 ) -> Result<JoinHandle<()>, String> {
     let handle = std::thread::Builder::new()
         .name("wasapi-loopback".into())
         .spawn(move || {
-            if let Err(e) = wasapi_loopback_thread(stop, paused, pcm, level, target_hz, max_seconds)
-            {
-                eprintln!("loopback thread: {e}");
+            if let Err(e) = wasapi_loopback_thread(stop, paused, pcm, level, target_hz) {
+                let msg = format!("loopback thread: {e}");
+                eprintln!("{msg}");
+                if let Ok(mut slot) = last_error.lock() {
+                    *slot = Some(msg);
+                }
             }
         })
         .map_err(|e| e.to_string())?;
@@ -233,10 +218,9 @@ fn spawn_wasapi_loopback(
 fn wasapi_loopback_thread(
     stop: Arc<AtomicBool>,
     paused: Arc<AtomicBool>,
-    pcm: Arc<Mutex<Vec<i16>>>,
+    pcm: Arc<PcmSink>,
     level: Arc<AtomicU32>,
     target_hz: u32,
-    max_seconds: usize,
 ) -> Result<(), String> {
     use windows::Win32::Media::Audio::{
         eConsole, eRender, IAudioCaptureClient, IAudioClient, IMMDeviceEnumerator,
@@ -279,7 +263,6 @@ fn wasapi_loopback_thread(
         let bits = format.wBitsPerSample;
         let is_float = format.wFormatTag == 3
             || (format.wFormatTag == 0xFFFE && bits == 32);
-        let max_samples = target_hz as usize * max_seconds;
 
         while !stop.load(Ordering::Relaxed) {
             let packet = capture
@@ -312,7 +295,6 @@ fn wasapi_loopback_thread(
                     channels,
                     sample_rate,
                     target_hz,
-                    max_samples,
                     paused.as_ref(),
                     pcm.as_ref(),
                     level.as_ref(),

--- a/desktop/src-tauri/src/audio/mod.rs
+++ b/desktop/src-tauri/src/audio/mod.rs
@@ -1,16 +1,25 @@
 pub mod capture;
 pub mod resample;
+pub mod sink;
 pub mod wav;
 
+use crate::groq;
+use crate::pipeline::{self, TranscriptSeg};
+use crate::secrets;
 use crate::AppState;
 use serde::Serialize;
+use sink::PcmSink;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
+use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
 
 const TARGET_HZ: u32 = 16_000;
-const MAX_SECONDS: usize = 90 * 60;
+const MAX_SECONDS: u64 = 90 * 60;
+const LIVE_TICK: Duration = Duration::from_secs(10);
+const LIVE_MIN_SAMPLES: u64 = TARGET_HZ as u64 * 4;
 
 #[derive(Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -27,6 +36,7 @@ pub struct RecStatus {
     pub pending_bytes: usize,
     pub loopback_ok: bool,
     pub meeting_id: Option<String>,
+    pub last_error: Option<String>,
 }
 
 #[derive(Serialize, Clone)]
@@ -35,11 +45,31 @@ pub struct VuLevels {
     pub system: f32,
 }
 
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveTranscriptBatch {
+    pub meeting_id: Option<String>,
+    pub segments: Vec<TranscriptSeg>,
+}
+
+pub struct PendingAudio {
+    pub dir: PathBuf,
+    pub mic: PathBuf,
+    pub sys: PathBuf,
+}
+
+impl PendingAudio {
+    pub fn cleanup(&self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
 pub struct Recorder {
     pub state: Mutex<RecState>,
-    pub pending_wav: Mutex<Option<Vec<u8>>>,
+    pub pending: Mutex<Option<PendingAudio>>,
     pub loopback_ok: Mutex<bool>,
     pub meeting_id: Mutex<Option<String>>,
+    pub last_error: Mutex<Option<String>>,
     session: Mutex<Option<LiveSession>>,
 }
 
@@ -49,17 +79,21 @@ struct LiveSession {
     mic: Option<JoinHandle<()>>,
     loopback: Option<JoinHandle<()>>,
     vu: Option<JoinHandle<()>>,
-    mic_pcm: Arc<Mutex<Vec<i16>>>,
-    sys_pcm: Arc<Mutex<Vec<i16>>>,
+    live: Option<JoinHandle<()>>,
+    mic_sink: Arc<PcmSink>,
+    sys_sink: Arc<PcmSink>,
+    dir: PathBuf,
+    last_error: Arc<Mutex<Option<String>>>,
 }
 
 impl Recorder {
     pub fn new() -> Self {
         Self {
             state: Mutex::new(RecState::Idle),
-            pending_wav: Mutex::new(None),
+            pending: Mutex::new(None),
             loopback_ok: Mutex::new(false),
             meeting_id: Mutex::new(None),
+            last_error: Mutex::new(None),
             session: Mutex::new(None),
         }
     }
@@ -69,42 +103,58 @@ fn recorder_of(app: &AppHandle) -> tauri::State<'_, AppState> {
     app.state::<AppState>()
 }
 
+fn session_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("app data dir: {e}"))?;
+    Ok(dir.join("recordings").join(crate::ids::new_id("rec")))
+}
+
 pub fn start(app: &AppHandle, meeting_id: Option<String>) -> Result<RecStatus, String> {
     let state = recorder_of(app);
     let recorder = &state.recorder;
     {
-        let state = recorder.state.lock().map_err(|e| e.to_string())?;
-        if *state != RecState::Idle {
+        let rec_state = recorder.state.lock().map_err(|e| e.to_string())?;
+        if *rec_state != RecState::Idle {
             return Err("already capturing".into());
         }
     }
 
-    *recorder.pending_wav.lock().map_err(|e| e.to_string())? = None;
-    *recorder.meeting_id.lock().map_err(|e| e.to_string())? = meeting_id;
+    if let Some(old) = recorder.pending.lock().map_err(|e| e.to_string())?.take() {
+        old.cleanup();
+    }
+    *recorder.last_error.lock().map_err(|e| e.to_string())? = None;
+    *recorder.meeting_id.lock().map_err(|e| e.to_string())? = meeting_id.clone();
+
+    let dir = session_dir(app)?;
+    std::fs::create_dir_all(&dir).map_err(|e| format!("recording dir: {e}"))?;
+    let max_samples = TARGET_HZ as u64 * MAX_SECONDS;
+    let mic_sink = Arc::new(PcmSink::create(dir.join("mic.pcm"), max_samples)?);
+    let sys_sink = Arc::new(PcmSink::create(dir.join("sys.pcm"), max_samples)?);
 
     let stop = Arc::new(AtomicBool::new(false));
     let paused = Arc::new(AtomicBool::new(false));
-    let mic_pcm = Arc::new(Mutex::new(Vec::new()));
-    let sys_pcm = Arc::new(Mutex::new(Vec::new()));
     let mic_level = Arc::new(AtomicU32::new(0));
     let sys_level = Arc::new(AtomicU32::new(0));
+    let last_error = Arc::new(Mutex::new(None));
 
     let mic = capture::start_mic(
         stop.clone(),
         paused.clone(),
-        mic_pcm.clone(),
+        mic_sink.clone(),
         mic_level.clone(),
+        last_error.clone(),
         TARGET_HZ,
-        MAX_SECONDS,
     )?;
 
     let (loopback, loopback_ok) = capture::start_loopback(
         stop.clone(),
         paused.clone(),
-        sys_pcm.clone(),
+        sys_sink.clone(),
         sys_level.clone(),
+        last_error.clone(),
         TARGET_HZ,
-        MAX_SECONDS,
     );
     *recorder.loopback_ok.lock().map_err(|e| e.to_string())? = loopback_ok;
 
@@ -112,14 +162,33 @@ pub fn start(app: &AppHandle, meeting_id: Option<String>) -> Result<RecStatus, S
     let vu_app = app.clone();
     let vu_mic = mic_level.clone();
     let vu_sys = sys_level.clone();
+    let vu_err = last_error.clone();
     let vu = std::thread::spawn(move || {
+        let mut last_emitted_err: Option<String> = None;
         while !vu_stop.load(Ordering::Relaxed) {
             let mic = f32::from_bits(vu_mic.load(Ordering::Relaxed));
             let system = f32::from_bits(vu_sys.load(Ordering::Relaxed));
             let _ = vu_app.emit("audio-vu", VuLevels { mic, system });
-            std::thread::sleep(std::time::Duration::from_millis(80));
+            if let Ok(slot) = vu_err.lock() {
+                if let Some(err) = slot.as_ref() {
+                    if last_emitted_err.as_ref() != Some(err) {
+                        last_emitted_err = Some(err.clone());
+                        let _ = vu_app.emit("recording-error", err.clone());
+                    }
+                }
+            }
+            std::thread::sleep(Duration::from_millis(80));
         }
     });
+
+    let live = spawn_live_stt(
+        app.clone(),
+        stop.clone(),
+        paused.clone(),
+        mic_sink.clone(),
+        sys_sink.clone(),
+        meeting_id,
+    );
 
     *recorder.session.lock().map_err(|e| e.to_string())? = Some(LiveSession {
         stop,
@@ -127,8 +196,11 @@ pub fn start(app: &AppHandle, meeting_id: Option<String>) -> Result<RecStatus, S
         mic: Some(mic),
         loopback,
         vu: Some(vu),
-        mic_pcm,
-        sys_pcm,
+        live: Some(live),
+        mic_sink,
+        sys_sink,
+        dir,
+        last_error,
     });
     *recorder.state.lock().map_err(|e| e.to_string())? = RecState::Recording;
     set_tray_tooltip(app, "Bagrry — Recording");
@@ -140,25 +212,27 @@ pub fn start(app: &AppHandle, meeting_id: Option<String>) -> Result<RecStatus, S
 pub fn pause(app: &AppHandle) -> Result<RecStatus, String> {
     let state = recorder_of(app);
     let recorder = &state.recorder;
-    let mut state = recorder.state.lock().map_err(|e| e.to_string())?;
-    match *state {
+    let current = {
+        let guard = recorder.state.lock().map_err(|e| e.to_string())?;
+        *guard
+    };
+    match current {
         RecState::Recording => {
             if let Some(session) = recorder.session.lock().map_err(|e| e.to_string())?.as_ref() {
                 session.paused.store(true, Ordering::Relaxed);
             }
-            *state = RecState::Paused;
+            *recorder.state.lock().map_err(|e| e.to_string())? = RecState::Paused;
             set_tray_tooltip(app, "Bagrry — Paused");
         }
         RecState::Paused => {
             if let Some(session) = recorder.session.lock().map_err(|e| e.to_string())?.as_ref() {
                 session.paused.store(false, Ordering::Relaxed);
             }
-            *state = RecState::Recording;
+            *recorder.state.lock().map_err(|e| e.to_string())? = RecState::Recording;
             set_tray_tooltip(app, "Bagrry — Recording");
         }
         RecState::Idle => return Err("not capturing".into()),
     }
-    drop(state);
     let status = status_of(recorder)?;
     let _ = app.emit("recording-state", status.clone());
     Ok(status)
@@ -167,9 +241,9 @@ pub fn pause(app: &AppHandle) -> Result<RecStatus, String> {
 pub fn stop(app: &AppHandle) -> Result<RecStatus, String> {
     let state = recorder_of(app);
     let recorder = &state.recorder;
-    let mut session_guard = recorder.session.lock().map_err(|e| e.to_string())?;
-    let Some(session) = session_guard.take() else {
-        return Err("not capturing".into());
+    let session = {
+        let mut session_guard = recorder.session.lock().map_err(|e| e.to_string())?;
+        session_guard.take().ok_or_else(|| "not capturing".to_string())?
     };
     session.stop.store(true, Ordering::Relaxed);
     if let Some(handle) = session.mic {
@@ -181,20 +255,34 @@ pub fn stop(app: &AppHandle) -> Result<RecStatus, String> {
     if let Some(handle) = session.vu {
         let _ = handle.join();
     }
+    if let Some(handle) = session.live {
+        let _ = handle.join();
+    }
 
-    let mic = session.mic_pcm.lock().map_err(|e| e.to_string())?.clone();
-    let sys = session.sys_pcm.lock().map_err(|e| e.to_string())?.clone();
-    session.mic_pcm.lock().map_err(|e| e.to_string())?.clear();
-    session.sys_pcm.lock().map_err(|e| e.to_string())?.clear();
-    drop(session_guard);
+    session.mic_sink.finish();
+    session.sys_sink.finish();
 
-    let wav = wav::encode_dual_mono_16k(&mic, &sys);
-    *recorder.pending_wav.lock().map_err(|e| e.to_string())? = Some(wav);
+    if let Ok(slot) = session.last_error.lock() {
+        *recorder.last_error.lock().map_err(|e| e.to_string())? = slot.clone();
+    }
+
+    let pending = PendingAudio {
+        dir: session.dir.clone(),
+        mic: session.mic_sink.path.clone(),
+        sys: session.sys_sink.path.clone(),
+    };
+    *recorder.pending.lock().map_err(|e| e.to_string())? = Some(pending);
     *recorder.state.lock().map_err(|e| e.to_string())? = RecState::Idle;
     set_tray_tooltip(app, "Bagrry — Idle");
     let status = status_of(recorder)?;
     let _ = app.emit("recording-state", status.clone());
-    let _ = app.emit("audio-vu", VuLevels { mic: 0.0, system: 0.0 });
+    let _ = app.emit(
+        "audio-vu",
+        VuLevels {
+            mic: 0.0,
+            system: 0.0,
+        },
+    );
     Ok(status)
 }
 
@@ -215,30 +303,22 @@ pub fn toggle(app: &AppHandle) -> Result<RecStatus, String> {
 pub fn discard_pending(app: &AppHandle) -> Result<RecStatus, String> {
     let state = recorder_of(app);
     let recorder = &state.recorder;
-    *recorder.pending_wav.lock().map_err(|e| e.to_string())? = None;
+    if let Some(pending) = recorder.pending.lock().map_err(|e| e.to_string())?.take() {
+        pending.cleanup();
+    }
     status_of(recorder)
 }
 
-pub fn take_pending_wav(app: &AppHandle) -> Result<Option<Vec<u8>>, String> {
+pub fn take_pending(app: &AppHandle) -> Result<Option<PendingAudio>, String> {
     let state = recorder_of(app);
-    let wav = state
-        .recorder
-        .pending_wav
-        .lock()
-        .map_err(|e| e.to_string())?
-        .take();
-    Ok(wav)
+    let mut guard = state.recorder.pending.lock().map_err(|e| e.to_string())?;
+    Ok(guard.take())
 }
 
-pub fn peek_pending_wav(app: &AppHandle) -> Result<Option<Vec<u8>>, String> {
+pub fn peek_pending(app: &AppHandle) -> Result<Option<(PathBuf, PathBuf)>, String> {
     let state = recorder_of(app);
-    let wav = state
-        .recorder
-        .pending_wav
-        .lock()
-        .map_err(|e| e.to_string())?
-        .clone();
-    Ok(wav)
+    let guard = state.recorder.pending.lock().map_err(|e| e.to_string())?;
+    Ok(guard.as_ref().map(|p| (p.mic.clone(), p.sys.clone())))
 }
 
 pub fn status(app: &AppHandle) -> Result<RecStatus, String> {
@@ -247,18 +327,103 @@ pub fn status(app: &AppHandle) -> Result<RecStatus, String> {
 }
 
 fn status_of(recorder: &Recorder) -> Result<RecStatus, String> {
+    let pending_bytes = pending_byte_count(recorder)?;
+    let last_error = {
+        let session = recorder.session.lock().map_err(|e| e.to_string())?;
+        session
+            .as_ref()
+            .and_then(|s| s.last_error.lock().ok().and_then(|e| e.clone()))
+    }
+    .or_else(|| recorder.last_error.lock().ok().and_then(|e| e.clone()));
     Ok(RecStatus {
         state: *recorder.state.lock().map_err(|e| e.to_string())?,
-        pending_bytes: recorder
-            .pending_wav
-            .lock()
-            .map_err(|e| e.to_string())?
-            .as_ref()
-            .map(|b| b.len())
-            .unwrap_or(0),
+        pending_bytes,
         loopback_ok: *recorder.loopback_ok.lock().map_err(|e| e.to_string())?,
         meeting_id: recorder.meeting_id.lock().map_err(|e| e.to_string())?.clone(),
+        last_error,
     })
+}
+
+fn pending_byte_count(recorder: &Recorder) -> Result<usize, String> {
+    {
+        let pending = recorder.pending.lock().map_err(|e| e.to_string())?;
+        if let Some(pending) = pending.as_ref() {
+            return Ok(file_len(&pending.mic) + file_len(&pending.sys));
+        }
+    }
+    let session = recorder.session.lock().map_err(|e| e.to_string())?;
+    Ok(session
+        .as_ref()
+        .map(|s| (s.mic_sink.byte_len() + s.sys_sink.byte_len()) as usize)
+        .unwrap_or(0))
+}
+
+fn file_len(path: &Path) -> usize {
+    std::fs::metadata(path).map(|m| m.len() as usize).unwrap_or(0)
+}
+
+fn spawn_live_stt(
+    app: AppHandle,
+    stop: Arc<AtomicBool>,
+    paused: Arc<AtomicBool>,
+    mic_sink: Arc<PcmSink>,
+    sys_sink: Arc<PcmSink>,
+    meeting_id: Option<String>,
+) -> JoinHandle<()> {
+    std::thread::Builder::new()
+        .name("live-stt".into())
+        .spawn(move || {
+            let mut cursor = 0u64;
+            while !stop.load(Ordering::Relaxed) {
+                let mut waited = Duration::ZERO;
+                while waited < LIVE_TICK && !stop.load(Ordering::Relaxed) {
+                    std::thread::sleep(Duration::from_millis(200));
+                    waited += Duration::from_millis(200);
+                }
+                if stop.load(Ordering::Relaxed) || paused.load(Ordering::Relaxed) {
+                    continue;
+                }
+                let n = mic_sink.sample_count().max(sys_sink.sample_count());
+                if n <= cursor + LIVE_MIN_SAMPLES {
+                    continue;
+                }
+                let start = cursor;
+                let len = n.saturating_sub(cursor);
+                cursor = n;
+                let mic = mic_sink.read_range(start, len).unwrap_or_default();
+                let sys = sys_sink.read_range(start, len).unwrap_or_default();
+                if resample::rms(&mic) < 0.008 && resample::rms(&sys) < 0.008 {
+                    continue;
+                }
+                let Some((key, opts)) = live_stt_creds(&app) else {
+                    continue;
+                };
+                match pipeline::transcribe_pcm_chunk(&key, &mic, &sys, &opts, start) {
+                    Ok(segments) if !segments.is_empty() => {
+                        let _ = app.emit(
+                            "live-transcript",
+                            LiveTranscriptBatch {
+                                meeting_id: meeting_id.clone(),
+                                segments,
+                            },
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(e) => eprintln!("live stt: {e}"),
+                }
+            }
+        })
+        .expect("spawn live-stt")
+}
+
+fn live_stt_creds(app: &AppHandle) -> Option<(String, groq::SttOptions)> {
+    let state = app.state::<AppState>();
+    let conn = state.conn().ok()?;
+    let key = secrets::get_secret(&conn, "groq_api_key").ok().flatten()?;
+    if key.is_empty() {
+        return None;
+    }
+    Some((key, pipeline::stt_options(&conn)))
 }
 
 pub fn set_tray_tooltip(app: &AppHandle, text: &str) {

--- a/desktop/src-tauri/src/audio/resample.rs
+++ b/desktop/src-tauri/src/audio/resample.rs
@@ -46,6 +46,8 @@ pub fn rms(samples: &[i16]) -> f32 {
     ((sum / samples.len() as f64).sqrt() as f32).clamp(0.0, 1.0)
 }
 
+/// Kept for tests and future in-memory capture caps.
+#[allow(dead_code)]
 pub fn push_capped(buf: &mut Vec<i16>, extra: &[i16], max_samples: usize) {
     buf.extend_from_slice(extra);
     if buf.len() > max_samples {

--- a/desktop/src-tauri/src/audio/sink.rs
+++ b/desktop/src-tauri/src/audio/sink.rs
@@ -1,0 +1,153 @@
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{mpsc, Mutex};
+use std::thread::JoinHandle;
+
+/// Disk-backed 16-bit PCM (little-endian, 16 kHz mono). Capture callbacks send
+/// short buffers over a channel so the audio thread never blocks on `write`.
+pub struct PcmSink {
+    pub path: PathBuf,
+    tx: Mutex<Option<mpsc::Sender<Vec<i16>>>>,
+    writer: Mutex<Option<JoinHandle<()>>>,
+    samples: AtomicU64,
+    max_samples: u64,
+}
+
+impl PcmSink {
+    pub fn create(path: PathBuf, max_samples: u64) -> Result<Self, String> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| format!("recording dir: {e}"))?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&path)
+            .map_err(|e| format!("open pcm {}: {e}", path.display()))?;
+        let (tx, rx) = mpsc::channel::<Vec<i16>>();
+        let writer = std::thread::Builder::new()
+            .name("pcm-writer".into())
+            .spawn(move || writer_loop(file, rx))
+            .map_err(|e| e.to_string())?;
+        Ok(Self {
+            path,
+            tx: Mutex::new(Some(tx)),
+            writer: Mutex::new(Some(writer)),
+            samples: AtomicU64::new(0),
+            max_samples,
+        })
+    }
+
+    pub fn push(&self, samples: &[i16]) {
+        if samples.is_empty() {
+            return;
+        }
+        let written = self.samples.load(Ordering::Relaxed);
+        if written >= self.max_samples {
+            return;
+        }
+        let room = (self.max_samples - written) as usize;
+        let slice = if samples.len() > room {
+            &samples[..room]
+        } else {
+            samples
+        };
+        if let Ok(guard) = self.tx.lock() {
+            if let Some(tx) = guard.as_ref() {
+                if tx.send(slice.to_vec()).is_ok() {
+                    self.samples
+                        .fetch_add(slice.len() as u64, Ordering::Relaxed);
+                }
+            }
+        }
+    }
+
+    pub fn sample_count(&self) -> u64 {
+        self.samples.load(Ordering::Relaxed)
+    }
+
+    pub fn byte_len(&self) -> u64 {
+        self.sample_count() * 2
+    }
+
+    pub fn read_range(&self, start: u64, len: u64) -> Result<Vec<i16>, String> {
+        read_i16_range(&self.path, start, len)
+    }
+
+    /// Drop the sender and wait for the writer to flush. Safe to call twice.
+    pub fn finish(&self) {
+        if let Ok(mut guard) = self.tx.lock() {
+            guard.take();
+        }
+        if let Ok(mut guard) = self.writer.lock() {
+            if let Some(handle) = guard.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+}
+
+impl Drop for PcmSink {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+fn writer_loop(mut file: File, rx: mpsc::Receiver<Vec<i16>>) {
+    while let Ok(chunk) = rx.recv() {
+        if chunk.is_empty() {
+            continue;
+        }
+        let bytes: Vec<u8> = chunk.iter().flat_map(|s| s.to_le_bytes()).collect();
+        if file.write_all(&bytes).is_err() {
+            break;
+        }
+        let _ = file.flush();
+    }
+    let _ = file.sync_all();
+}
+
+pub fn read_i16_range(path: &Path, start: u64, len: u64) -> Result<Vec<i16>, String> {
+    if len == 0 {
+        return Ok(Vec::new());
+    }
+    let mut file = File::open(path).map_err(|e| format!("read pcm {}: {e}", path.display()))?;
+    let meta = file
+        .metadata()
+        .map_err(|e| format!("pcm metadata: {e}"))?;
+    let available = meta.len() / 2;
+    if start >= available {
+        return Ok(Vec::new());
+    }
+    let take = len.min(available - start);
+    file.seek(SeekFrom::Start(start * 2))
+        .map_err(|e| format!("seek pcm: {e}"))?;
+    let mut buf = vec![0u8; (take * 2) as usize];
+    file.read_exact(&mut buf)
+        .map_err(|e| format!("read pcm bytes: {e}"))?;
+    Ok(buf
+        .chunks_exact(2)
+        .map(|c| i16::from_le_bytes([c[0], c[1]]))
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_pcm_range() {
+        let dir = std::env::temp_dir().join(format!("bagrry-pcm-{}", std::process::id()));
+        let path = dir.join("t.pcm");
+        let sink = PcmSink::create(path.clone(), 16_000).unwrap();
+        sink.push(&[1, 2, 3, 4, 5, 6, 7, 8]);
+        sink.finish();
+        assert_eq!(sink.sample_count(), 8);
+        let mid = read_i16_range(&path, 2, 3).unwrap();
+        assert_eq!(mid, vec![3, 4, 5]);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}
+

--- a/desktop/src-tauri/src/audio/wav.rs
+++ b/desktop/src-tauri/src/audio/wav.rs
@@ -1,3 +1,5 @@
+/// Kept for compact in-memory dual-mono WAVs (tests and older callers).
+#[allow(dead_code)]
 pub fn encode_dual_mono_16k(mic: &[i16], system: &[i16]) -> Vec<u8> {
     let frames = mic.len().max(system.len());
     let data_bytes = frames * 4;
@@ -46,6 +48,7 @@ pub fn encode_mono_16k(samples: &[i16]) -> Vec<u8> {
     out
 }
 
+#[allow(dead_code)]
 pub fn split_dual_mono(wav: &[u8]) -> Result<(Vec<u8>, Vec<u8>), String> {
     if wav.len() < 44 {
         return Err("wav too short".into());

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -312,37 +312,21 @@ pub fn discard_audio(app: AppHandle) -> Result<audio::RecStatus, String> {
 
 #[tauri::command]
 pub fn transcribe_pending(app: AppHandle, state: State<AppState>, meeting_id: String) -> Result<Vec<TranscriptSeg>, String> {
-    let wav = audio::peek_pending_wav(&app)?.ok_or_else(|| "no audio in memory".to_string())?;
+    let (mic, sys) = audio::peek_pending(&app)?.ok_or_else(|| "no audio captured".to_string())?;
     let conn = state.conn()?;
     let key = secrets::get_secret(&conn, "groq_api_key")?.ok_or_else(|| {
         "Add a Groq API key in Settings to transcribe.".to_string()
     })?;
-    let opts = stt_options(&conn);
+    let opts = pipeline::stt_options(&conn);
     drop(conn);
-    let segs = pipeline::transcribe_dual_wav(&key, &wav, &opts)?;
+    let segs = pipeline::transcribe_pcm_files(&key, &mic, &sys, &opts)?;
     let conn = state.conn()?;
     pipeline::persist_transcript(&conn, &meeting_id, &segs)?;
-    let _ = audio::take_pending_wav(&app);
+    if let Some(pending) = audio::take_pending(&app)? {
+        pending.cleanup();
+    }
     notify(&app, &conn, "Transcript ready", "Your meeting transcript has finished processing.");
     Ok(segs)
-}
-
-/// Maps the `transcription_language` setting ("en-best" | "en" | "auto" | ISO code)
-/// plus internal jargon to Whisper request options.
-fn stt_options(conn: &rusqlite::Connection) -> groq::SttOptions {
-    let lang_setting = secrets::get_setting(conn, "transcription_language", "en-best");
-    let language = match lang_setting.as_str() {
-        "auto" => None,
-        "en-best" => Some("en".to_string()),
-        other => Some(other.split('-').next().unwrap_or("en").to_string()),
-    };
-    let jargon = secrets::get_setting(conn, "internal_jargon", "");
-    let model = secrets::get_setting(conn, "stt_model", "whisper-large-v3-turbo");
-    groq::SttOptions {
-        language,
-        prompt: (!jargon.is_empty()).then_some(jargon),
-        model: (!model.trim().is_empty()).then_some(model),
-    }
 }
 
 fn chat_model(conn: &rusqlite::Connection) -> String {

--- a/desktop/src-tauri/src/pipeline.rs
+++ b/desktop/src-tauri/src/pipeline.rs
@@ -1,8 +1,12 @@
+use crate::audio::sink;
 use crate::audio::wav;
 use crate::groq::{self, Bullet, EnhancedDoc, Section};
 use crate::ids::new_id;
+use crate::secrets;
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::time::Duration;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TranscriptSeg {
@@ -15,6 +19,7 @@ pub struct TranscriptSeg {
     pub sentence_id: String,
 }
 
+#[allow(dead_code)]
 pub fn transcribe_dual_wav(
     api_key: &str,
     wav_bytes: &[u8],
@@ -23,22 +28,172 @@ pub fn transcribe_dual_wav(
     let (mic, sys) = wav::split_dual_mono(wav_bytes)?;
     let mut segs = Vec::new();
     if wav_has_signal(&mic) {
-        let mic_res = groq::transcribe_wav(api_key, &mic, "mic.wav", opts)?;
-        push_channel(&mut segs, &mic_res, "me");
+        let mic_res = transcribe_with_retry(api_key, &mic, "mic.wav", opts)?;
+        push_channel(&mut segs, &mic_res, "me", 0, 0);
     }
     if wav_has_signal(&sys) {
-        let sys_res = groq::transcribe_wav(api_key, &sys, "system.wav", opts)?;
-        push_channel(&mut segs, &sys_res, "attendees");
+        let sys_res = transcribe_with_retry(api_key, &sys, "system.wav", opts)?;
+        push_channel(&mut segs, &sys_res, "attendees", 0, 0);
     }
     segs.sort_by_key(|s| s.start_ms);
-    for (i, s) in segs.iter_mut().enumerate() {
-        s.sentence_index = i as i64;
-        s.sentence_id = format!("s_{:03}", i + 1);
-        s.id = new_id("seg");
+    number_segments(&mut segs);
+    Ok(segs)
+}
+
+/// Maps `transcription_language` + jargon + Whisper model from settings.
+pub fn stt_options(conn: &Connection) -> groq::SttOptions {
+    let lang_setting = secrets::get_setting(conn, "transcription_language", "en-best");
+    let language = match lang_setting.as_str() {
+        "auto" => None,
+        "en-best" => Some("en".to_string()),
+        other => Some(other.split('-').next().unwrap_or("en").to_string()),
+    };
+    let jargon = secrets::get_setting(conn, "internal_jargon", "");
+    let model = secrets::get_setting(conn, "stt_model", "whisper-large-v3-turbo");
+    groq::SttOptions {
+        language,
+        prompt: (!jargon.is_empty()).then_some(jargon),
+        model: (!model.trim().is_empty()).then_some(model),
+    }
+}
+
+const STT_HZ: u64 = 16_000;
+/// ~8 minutes of 16 kHz 16-bit mono stays under Groq's 25 MB upload cap.
+const CHUNK_SAMPLES: u64 = STT_HZ * 8 * 60;
+const OVERLAP_SAMPLES: u64 = STT_HZ * 2;
+const MAX_STT_ATTEMPTS: u32 = 3;
+
+/// Final transcription of a dual-mono recording spilled to disk as raw PCM.
+pub fn transcribe_pcm_files(
+    api_key: &str,
+    mic_path: &Path,
+    sys_path: &Path,
+    opts: &groq::SttOptions,
+) -> Result<Vec<TranscriptSeg>, String> {
+    let mut segs = Vec::new();
+    segs.extend(transcribe_pcm_channel(api_key, mic_path, "me", opts)?);
+    segs.extend(transcribe_pcm_channel(api_key, sys_path, "attendees", opts)?);
+    segs.sort_by_key(|s| s.start_ms);
+    number_segments(&mut segs);
+    Ok(segs)
+}
+
+/// Live window: a few seconds of PCM already at 16 kHz, with a sample offset.
+pub fn transcribe_pcm_chunk(
+    api_key: &str,
+    mic: &[i16],
+    sys: &[i16],
+    opts: &groq::SttOptions,
+    start_sample: u64,
+) -> Result<Vec<TranscriptSeg>, String> {
+    let offset_ms = ((start_sample * 1000) / STT_HZ) as i64;
+    let mut segs = Vec::new();
+    if pcm_has_signal(mic) {
+        let wav = wav::encode_mono_16k(mic);
+        let result = transcribe_with_retry(api_key, &wav, "live-mic.wav", opts)?;
+        push_channel(&mut segs, &result, "me", offset_ms, 0);
+    }
+    if pcm_has_signal(sys) {
+        let wav = wav::encode_mono_16k(sys);
+        let result = transcribe_with_retry(api_key, &wav, "live-sys.wav", opts)?;
+        push_channel(&mut segs, &result, "attendees", offset_ms, 0);
+    }
+    segs.sort_by_key(|s| s.start_ms);
+    number_segments(&mut segs);
+    Ok(segs)
+}
+
+fn transcribe_pcm_channel(
+    api_key: &str,
+    path: &Path,
+    speaker: &str,
+    opts: &groq::SttOptions,
+) -> Result<Vec<TranscriptSeg>, String> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let total = std::fs::metadata(path)
+        .map_err(|e| format!("pcm metadata: {e}"))?
+        .len()
+        / 2;
+    if total < STT_HZ / 2 {
+        return Ok(Vec::new());
+    }
+    let mut segs = Vec::new();
+    let mut start = 0u64;
+    let mut chunk_idx = 0u32;
+    while start < total {
+        let len = CHUNK_SAMPLES.min(total - start);
+        let pcm = sink::read_i16_range(path, start, len)?;
+        if pcm_has_signal(&pcm) {
+            let wav = wav::encode_mono_16k(&pcm);
+            let filename = format!("{speaker}-{chunk_idx}.wav");
+            let result = transcribe_with_retry(api_key, &wav, &filename, opts)?;
+            let offset_ms = ((start * 1000) / STT_HZ) as i64;
+            let skip_ms = if chunk_idx == 0 {
+                0
+            } else {
+                ((OVERLAP_SAMPLES * 1000) / STT_HZ) as i64
+            };
+            push_channel(&mut segs, &result, speaker, offset_ms, skip_ms);
+        }
+        if start + len >= total {
+            break;
+        }
+        start += len.saturating_sub(OVERLAP_SAMPLES);
+        chunk_idx += 1;
     }
     Ok(segs)
 }
 
+fn transcribe_with_retry(
+    api_key: &str,
+    wav: &[u8],
+    filename: &str,
+    opts: &groq::SttOptions,
+) -> Result<groq::WhisperVerbose, String> {
+    let mut last = String::new();
+    for attempt in 0..MAX_STT_ATTEMPTS {
+        match groq::transcribe_wav(api_key, wav, filename, opts) {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                last = e;
+                let retry = attempt + 1 < MAX_STT_ATTEMPTS && is_retryable_stt(&last);
+                if !retry {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(400 * 2u64.pow(attempt)));
+            }
+        }
+    }
+    Err(last)
+}
+
+fn is_retryable_stt(err: &str) -> bool {
+    let lower = err.to_ascii_lowercase();
+    lower.contains("429")
+        || lower.contains("502")
+        || lower.contains("503")
+        || lower.contains("504")
+        || lower.contains("stt request")
+        || lower.contains("timed out")
+}
+
+fn pcm_has_signal(pcm: &[i16]) -> bool {
+    pcm.iter().any(|s| s.unsigned_abs() > 8)
+}
+
+fn number_segments(segs: &mut [TranscriptSeg]) {
+    for (i, s) in segs.iter_mut().enumerate() {
+        s.sentence_index = i as i64;
+        s.sentence_id = format!("s_{:03}", i + 1);
+        if s.id.is_empty() {
+            s.id = new_id("seg");
+        }
+    }
+}
+
+#[allow(dead_code)]
 fn wav_has_signal(wav: &[u8]) -> bool {
     if wav.len() < 46 {
         return false;
@@ -48,7 +203,13 @@ fn wav_has_signal(wav: &[u8]) -> bool {
         .any(|c| i16::from_le_bytes([c[0], c[1]]).unsigned_abs() > 8)
 }
 
-fn push_channel(out: &mut Vec<TranscriptSeg>, result: &groq::WhisperVerbose, speaker: &str) {
+fn push_channel(
+    out: &mut Vec<TranscriptSeg>,
+    result: &groq::WhisperVerbose,
+    speaker: &str,
+    offset_ms: i64,
+    skip_before_ms: i64,
+) {
     if let Some(segments) = &result.segments {
         for seg in segments {
             let text = seg.text.clone().unwrap_or_default().trim().to_string();
@@ -56,19 +217,25 @@ fn push_channel(out: &mut Vec<TranscriptSeg>, result: &groq::WhisperVerbose, spe
                 continue;
             }
             let start_ms = (seg.start.unwrap_or(0.0) * 1000.0) as i64;
+            if start_ms < skip_before_ms {
+                continue;
+            }
             let end_ms = (seg.end.unwrap_or(0.0) * 1000.0) as i64;
             for sentence in split_sentences(&text) {
                 out.push(TranscriptSeg {
                     id: String::new(),
                     speaker: speaker.into(),
-                    start_ms,
-                    end_ms,
+                    start_ms: start_ms + offset_ms,
+                    end_ms: end_ms + offset_ms,
                     text: sentence,
                     sentence_index: 0,
                     sentence_id: String::new(),
                 });
             }
         }
+        return;
+    }
+    if skip_before_ms > 0 {
         return;
     }
     if let Some(text) = &result.text {
@@ -79,8 +246,8 @@ fn push_channel(out: &mut Vec<TranscriptSeg>, result: &groq::WhisperVerbose, spe
             out.push(TranscriptSeg {
                 id: String::new(),
                 speaker: speaker.into(),
-                start_ms: 0,
-                end_ms: 0,
+                start_ms: offset_ms,
+                end_ms: offset_ms,
                 text: sentence,
                 sentence_index: 0,
                 sentence_id: String::new(),
@@ -125,9 +292,10 @@ pub fn persist_transcript(
         .map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string(segs).map_err(|e| e.to_string())?;
+    let duration_ms = segs.iter().map(|s| s.end_ms).max().unwrap_or(0);
     conn.execute(
-        "UPDATE meetings SET transcript_json = ?1, updated_at = datetime('now') WHERE id = ?2",
-        params![json, meeting_id],
+        "UPDATE meetings SET transcript_json = ?1, duration_ms = ?2, updated_at = datetime('now') WHERE id = ?3",
+        params![json, duration_ms, meeting_id],
     )
     .map_err(|e| e.to_string())?;
     Ok(())

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -5,7 +5,7 @@ import { AnimatePresence, MotionConfig, motion } from "framer-motion";
 import * as api from "@/lib/api";
 import { currentWindow, isTauri } from "@/lib/tauri";
 import { watchSystemTheme } from "@/lib/theme";
-import { routeKey, type RecStatus, type VuLevels } from "@/lib/types";
+import { routeKey, type LiveTranscriptBatch, type RecStatus, type VuLevels } from "@/lib/types";
 import { useAppStore } from "@/store/app";
 import { useGlobalShortcuts } from "@/hooks/useGlobalShortcuts";
 import { useMeetingReminders, useRecordingStartToast } from "@/hooks/useMeetingReminders";
@@ -14,7 +14,7 @@ import { SidebarRail } from "@/components/layout/SidebarRail";
 import { TitleBar } from "@/components/layout/TitleBar";
 import { CommandPalette } from "@/components/CommandPalette";
 import { Onboarding } from "@/components/Onboarding";
-import { Toaster } from "@/components/ui/toast";
+import { Toaster, toast } from "@/components/ui/toast";
 import { HomePage } from "@/components/pages/HomePage";
 import { NotePage } from "@/components/pages/NotePage";
 import { ChatPage } from "@/components/pages/ChatPage";
@@ -85,6 +85,7 @@ export default function App() {
 function useRecordingBridge() {
   const applyRecStatus = useAppStore((s) => s.applyRecStatus);
   const setVu = useAppStore((s) => s.setVu);
+  const appendLiveSegments = useAppStore((s) => s.appendLiveSegments);
 
   useEffect(() => {
     if (!isTauri()) return;
@@ -104,12 +105,18 @@ function useRecordingBridge() {
 
     register<RecStatus>("recording-state", applyRecStatus);
     register<VuLevels>("audio-vu", setVu);
+    register<LiveTranscriptBatch>("live-transcript", (batch) => {
+      appendLiveSegments(batch.segments ?? []);
+    });
+    register<string>("recording-error", (message) => {
+      if (message) toast.error(message, "Capture issue");
+    });
 
     return () => {
       disposed = true;
       unlisteners.forEach((fn) => fn());
     };
-  }, [applyRecStatus, setVu]);
+  }, [applyRecStatus, setVu, appendLiveSegments]);
 }
 
 function useSystemThemeSync() {

--- a/desktop/src/components/notes/RecordingControls.tsx
+++ b/desktop/src/components/notes/RecordingControls.tsx
@@ -10,11 +10,24 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useSetting } from "@/hooks/useSetting";
 import { VuMeter } from "./VuMeter";
 import { Elapsed } from "./TranscriptPanel";
+
+const TRANSCRIPTION_LANGS = [
+  { id: "en-best", label: "English" },
+  { id: "en", label: "English (fast)" },
+  { id: "es", label: "Spanish" },
+  { id: "fr", label: "French" },
+  { id: "de", label: "German" },
+  { id: "pt", label: "Portuguese" },
+  { id: "auto", label: "Detect" },
+] as const;
 
 /**
  * Transport for the recorder. Stopping also kicks off transcription, which is
@@ -26,6 +39,8 @@ export function RecordingControls({ noteId, compact }: { noteId: string; compact
   const startedAt = useAppStore((s) => s.recordingStartedAt);
   const applyRecStatus = useAppStore((s) => s.applyRecStatus);
   const loopbackOk = useAppStore((s) => s.loopbackOk);
+  const clearLiveSegments = useAppStore((s) => s.clearLiveSegments);
+  const [transcriptionLang, setTranscriptionLang] = useSetting("transcription_language", "en-best");
 
   const start = useMutation({
     mutationFn: () => api.startRecording(noteId),
@@ -47,11 +62,12 @@ export function RecordingControls({ noteId, compact }: { noteId: string; compact
       await api.transcribePending(noteId);
     },
     onSuccess: () => {
+      clearLiveSegments();
       void queryClient.invalidateQueries({ queryKey: api.qk.segments(noteId) });
       void queryClient.invalidateQueries({ queryKey: api.qk.meeting(noteId) });
       toast.success("Recording transcribed");
     },
-    onError: (e) => toast.error(e, "The audio is still in memory — you can retry."),
+    onError: (e) => toast.error(e, "Audio is still on disk — you can retry."),
   });
 
   const discard = useMutation({
@@ -143,14 +159,28 @@ export function RecordingControls({ noteId, compact }: { noteId: string; compact
             </DropdownMenuContent>
           </DropdownMenu>
 
-          <button
-            type="button"
-            className="flex h-6 items-center gap-1 rounded-md px-1.5 text-[11px] text-muted transition-colors hover:bg-hover hover:text-text"
-          >
-            <Languages className="size-3.5" />
-            English
-            <ChevronDown className="size-3" />
-          </button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="flex h-6 items-center gap-1 rounded-md px-1.5 text-[11px] text-muted transition-colors hover:bg-hover hover:text-text"
+              >
+                <Languages className="size-3.5" />
+                {TRANSCRIPTION_LANGS.find((l) => l.id === transcriptionLang)?.label ?? "Language"}
+                <ChevronDown className="size-3" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuLabel>Transcription language</DropdownMenuLabel>
+              <DropdownMenuRadioGroup value={transcriptionLang} onValueChange={setTranscriptionLang}>
+                {TRANSCRIPTION_LANGS.map((lang) => (
+                  <DropdownMenuRadioItem key={lang.id} value={lang.id}>
+                    {lang.label}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </>
       )}
     </div>

--- a/desktop/src/components/notes/TranscriptPanel.tsx
+++ b/desktop/src/components/notes/TranscriptPanel.tsx
@@ -22,6 +22,7 @@ export function TranscriptPanel({ noteId }: { noteId: string }) {
   const setMinimized = useAppStore((s) => s.setTranscriptMinimized);
   const setOpen = useAppStore((s) => s.setTranscriptOpen);
   const startedAt = useAppStore((s) => s.recordingStartedAt);
+  const liveSegments = useAppStore((s) => s.liveSegments);
 
   const [query, setQuery] = useState("");
   const [searching, setSearching] = useState(false);
@@ -37,17 +38,24 @@ export function TranscriptPanel({ noteId }: { noteId: string }) {
   });
 
   const filtered = useMemo(() => {
-    if (!query.trim()) return segments;
+    const source =
+      recState !== "idle" && liveSegments.length > 0
+        ? liveSegments
+        : recState !== "idle"
+          ? [...segments, ...liveSegments]
+          : segments;
+    if (!query.trim()) return source;
     const needle = query.toLowerCase();
-    return segments.filter((s) => s.text.toLowerCase().includes(needle));
-  }, [segments, query]);
+    return source.filter((s) => s.text.toLowerCase().includes(needle));
+  }, [segments, liveSegments, recState, query]);
 
   useEffect(() => {
     if (!query) scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
   }, [filtered.length, query]);
 
   const copyAll = async () => {
-    const text = segments.map((s) => `${s.speaker === "me" ? "Me" : "Them"}: ${s.text}`).join("\n");
+    const rows = filtered.length ? filtered : segments;
+    const text = rows.map((s) => `${s.speaker === "me" ? "Me" : "Them"}: ${s.text}`).join("\n");
     try {
       await navigator.clipboard.writeText(text);
       toast.success("Transcript copied");
@@ -143,8 +151,8 @@ export function TranscriptPanel({ noteId }: { noteId: string }) {
                     <p className="text-[13px] text-subtle">
                       {query
                         ? "No matching lines"
-                        : recState === "recording"
-                          ? "Transcript starting…"
+                        : recState === "recording" || recState === "paused"
+                          ? "Listening… transcript will appear shortly"
                           : "Nothing transcribed yet"}
                     </p>
                   </div>

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -57,6 +57,8 @@ export type RecStatus = {
   loopbackOk?: boolean;
   meeting_id?: string | null;
   meetingId?: string | null;
+  last_error?: string | null;
+  lastError?: string | null;
 };
 
 export type NormalizedRecStatus = {
@@ -64,6 +66,7 @@ export type NormalizedRecStatus = {
   pendingBytes: number;
   loopbackOk: boolean;
   meetingId: string | null;
+  lastError: string | null;
 };
 
 export function normalizeRecStatus(status: RecStatus): NormalizedRecStatus {
@@ -72,8 +75,15 @@ export function normalizeRecStatus(status: RecStatus): NormalizedRecStatus {
     pendingBytes: status.pending_bytes ?? status.pendingBytes ?? 0,
     loopbackOk: status.loopback_ok ?? status.loopbackOk ?? false,
     meetingId: status.meeting_id ?? status.meetingId ?? null,
+    lastError: status.last_error ?? status.lastError ?? null,
   };
 }
+
+export type LiveTranscriptBatch = {
+  meetingId?: string | null;
+  meeting_id?: string | null;
+  segments: TranscriptSeg[];
+};
 
 export type VuLevels = {
   mic: number;

--- a/desktop/src/store/app.ts
+++ b/desktop/src/store/app.ts
@@ -7,6 +7,7 @@ import {
   type RecStatus,
   type Route,
   type SettingsTab,
+  type TranscriptSeg,
   type VuLevels,
 } from "@/lib/types";
 import {
@@ -71,9 +72,13 @@ type AppState = {
   recordingStartedAt: number | null;
   pendingBytes: number;
   loopbackOk: boolean;
+  lastError: string | null;
   vu: VuLevels;
   applyRecStatus: (status: RecStatus) => void;
   setVu: (vu: VuLevels) => void;
+  liveSegments: TranscriptSeg[];
+  appendLiveSegments: (segments: TranscriptSeg[]) => void;
+  clearLiveSegments: () => void;
 
   /* Transcript panel */
   transcriptOpen: boolean;
@@ -151,7 +156,9 @@ export const useAppStore = create<AppState>((set, get) => ({
   recordingStartedAt: null,
   pendingBytes: 0,
   loopbackOk: false,
+  lastError: null,
   vu: { mic: 0, system: 0 },
+  liveSegments: [],
 
   applyRecStatus: (status) => {
     const next = normalizeRecStatus(status);
@@ -161,7 +168,9 @@ export const useAppStore = create<AppState>((set, get) => ({
       recordingMeetingId: next.meetingId,
       pendingBytes: next.pendingBytes,
       loopbackOk: next.loopbackOk,
-      // Keep the original start time across pause/resume so the clock is continuous.
+      lastError: next.lastError,
+      // A new capture starts empty; leftover live lines stay until stop transcribes.
+      liveSegments: wasIdle && next.state !== "idle" ? [] : get().liveSegments,
       recordingStartedAt:
         next.state === "idle" ? null : wasIdle ? Date.now() : (get().recordingStartedAt ?? Date.now()),
       transcriptOpen: next.state === "idle" ? get().transcriptOpen : true,
@@ -170,6 +179,11 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   setVu: (vu) => set({ vu }),
+  appendLiveSegments: (segments) => {
+    if (segments.length === 0) return;
+    set({ liveSegments: [...get().liveSegments, ...segments] });
+  },
+  clearLiveSegments: () => set({ liveSegments: [] }),
 
   transcriptOpen: false,
   transcriptMinimized: false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Recording used to keep the whole meeting in RAM and could deadlock if you paused while stopping. This moves capture onto disk and makes transcription work for long meetings.

### Recorder
- Pause and stop no longer hold `state` and `session` at the same time
- Mic (and Windows loopback) write 16 kHz PCM to `app_data/recordings/<id>/` via a dedicated writer thread
- Capture failures emit `recording-error` and show up on `RecStatus.lastError`

### Transcription
- Final STT reads PCM in ~8 minute chunks (under Groq’s 25 MB cap) with 2s overlap stitching
- 429/5xx retries with backoff
- A live STT tick every ~10s emits `live-transcript` so the panel fills in while you talk
- Meeting `duration_ms` is set from the last segment

### UI
- Transcript panel shows rolling live lines
- Language menu writes `transcription_language`
- Retry copy says audio is on disk, not “in memory”

Stacks on #22.

`cargo check`, `cargo test audio::sink`, and `tsc --noEmit` pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

