### PR TITLE
Persist ProseMirror JSON, slash/bubble menus, editable enhanced notes

### DIFF
--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -38,6 +38,7 @@ pub struct Meeting {
     pub duration_ms: Option<i64>,
     pub calendar_event_id: Option<String>,
     pub scratchpad_raw: String,
+    pub scratchpad_json: Option<String>,
     pub enhanced_notes_json: Option<String>,
     pub transcript_json: Option<String>,
     pub updated_at: String,
@@ -109,13 +110,14 @@ fn meeting_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Meeting> {
         duration_ms: row.get(4)?,
         calendar_event_id: row.get(5)?,
         scratchpad_raw: row.get(6)?,
-        enhanced_notes_json: row.get(7)?,
-        transcript_json: row.get(8)?,
-        updated_at: row.get(9)?,
+        scratchpad_json: row.get(7)?,
+        enhanced_notes_json: row.get(8)?,
+        transcript_json: row.get(9)?,
+        updated_at: row.get(10)?,
     })
 }
 
-const MEETING_COLS: &str = "id, folder_id, title, date, duration_ms, calendar_event_id, scratchpad_raw, enhanced_notes_json, transcript_json, updated_at";
+const MEETING_COLS: &str = "id, folder_id, title, date, duration_ms, calendar_event_id, scratchpad_raw, scratchpad_json, enhanced_notes_json, transcript_json, updated_at";
 
 #[tauri::command]
 pub fn db_status(app: AppHandle, state: State<AppState>) -> Result<DbStatus, String> {
@@ -259,11 +261,36 @@ pub fn create_meeting(
 }
 
 #[tauri::command]
-pub fn save_scratchpad(state: State<AppState>, id: String, scratchpad_raw: String) -> Result<(), String> {
+pub fn save_scratchpad(
+    state: State<AppState>,
+    id: String,
+    scratchpad_raw: String,
+    scratchpad_json: Option<String>,
+) -> Result<(), String> {
     let conn = state.conn()?;
     conn.execute(
-        "UPDATE meetings SET scratchpad_raw = ?1, updated_at = datetime('now') WHERE id = ?2",
-        params![scratchpad_raw, id],
+        "UPDATE meetings SET scratchpad_raw = ?1, scratchpad_json = ?2, updated_at = datetime('now') WHERE id = ?3",
+        params![scratchpad_raw, scratchpad_json, id],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn save_enhanced_notes(
+    state: State<AppState>,
+    id: String,
+    enhanced_notes_json: String,
+) -> Result<(), String> {
+    let conn = state.conn()?;
+    let segs = pipeline::load_segments(&conn, &id).unwrap_or_default();
+    let mut doc: groq::EnhancedDoc =
+        serde_json::from_str(&enhanced_notes_json).map_err(|e| e.to_string())?;
+    pipeline::validate_citations(&mut doc, &segs);
+    let json = serde_json::to_string(&doc).map_err(|e| e.to_string())?;
+    conn.execute(
+        "UPDATE meetings SET enhanced_notes_json = ?1, updated_at = datetime('now') WHERE id = ?2",
+        params![json, id],
     )
     .map_err(|e| e.to_string())?;
     Ok(())
@@ -428,7 +455,7 @@ pub fn enhance_meeting(
     let ctx = enhance_context(&conn);
     let model = chat_model(&conn);
     drop(conn);
-    let doc = pipeline::enhance(
+    let mut doc = pipeline::enhance(
         key.as_deref(),
         &meeting.scratchpad_raw,
         &segs,
@@ -437,6 +464,7 @@ pub fn enhance_meeting(
         &ctx,
         Some(&model),
     )?;
+    pipeline::validate_citations(&mut doc, &segs);
     let json = serde_json::to_string(&doc).map_err(|e| e.to_string())?;
     let conn = state.conn()?;
     conn.execute(
@@ -1122,13 +1150,14 @@ pub fn duplicate_meeting(state: State<AppState>, id: String) -> Result<Meeting, 
         .map_err(|e| e.to_string())?;
     let new = new_id("mtg");
     conn.execute(
-        "INSERT INTO meetings (id, folder_id, title, date, scratchpad_raw, enhanced_notes_json)
-         VALUES (?1, ?2, ?3, datetime('now'), ?4, ?5)",
+        "INSERT INTO meetings (id, folder_id, title, date, scratchpad_raw, scratchpad_json, enhanced_notes_json)
+         VALUES (?1, ?2, ?3, datetime('now'), ?4, ?5, ?6)",
         params![
             &new,
             source.folder_id,
             format!("{} (copy)", source.title),
             source.scratchpad_raw,
+            source.scratchpad_json,
             source.enhanced_notes_json,
         ],
     )

--- a/desktop/src-tauri/src/db/migrations.rs
+++ b/desktop/src-tauri/src/db/migrations.rs
@@ -330,6 +330,11 @@ CREATE TABLE IF NOT EXISTS api_keys (
 );
 "#;
 
+/// ProseMirror JSON for the scratchpad, with plaintext remaining in scratchpad_raw.
+const V7: &str = r#"
+ALTER TABLE meetings ADD COLUMN scratchpad_json TEXT;
+"#;
+
 pub fn apply(conn: &Connection, vec_enabled: bool) -> Result<(), String> {
     let current: i64 = conn
         .query_row(
@@ -406,6 +411,16 @@ pub fn apply(conn: &Connection, vec_enabled: bool) -> Result<(), String> {
             [],
         )
         .map_err(|e| format!("record v6: {e}"))?;
+    }
+
+    if current < 7 {
+        conn.execute_batch(V7)
+            .map_err(|e| format!("migration v7: {e}"))?;
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version) VALUES (7)",
+            [],
+        )
+        .map_err(|e| format!("record v7: {e}"))?;
     }
 
     if vec_enabled {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -81,6 +81,7 @@ pub fn run() {
             commands::create_meeting,
             commands::duplicate_meeting,
             commands::save_scratchpad,
+            commands::save_enhanced_notes,
             commands::save_title,
             commands::delete_meeting,
             commands::move_meeting,

--- a/desktop/src-tauri/src/pipeline.rs
+++ b/desktop/src-tauri/src/pipeline.rs
@@ -301,6 +301,16 @@ pub fn persist_transcript(
     Ok(())
 }
 
+/// Drops citation ids that are not in this meeting's transcript.
+pub fn validate_citations(doc: &mut groq::EnhancedDoc, segs: &[TranscriptSeg]) {
+    let ids: std::collections::HashSet<&str> = segs.iter().map(|s| s.sentence_id.as_str()).collect();
+    for section in &mut doc.sections {
+        for bullet in &mut section.bullet_points {
+            bullet.citations.retain(|c| ids.contains(c.as_str()));
+        }
+    }
+}
+
 pub fn load_segments(conn: &Connection, meeting_id: &str) -> Result<Vec<TranscriptSeg>, String> {
     let mut stmt = conn
         .prepare(

--- a/desktop/src/components/notes/EnhancedNotes.tsx
+++ b/desktop/src/components/notes/EnhancedNotes.tsx
@@ -15,7 +15,15 @@ function parseDoc(json: string | null): EnhancedDoc | null {
   }
 }
 
-export function EnhancedNotes({ noteId, json }: { noteId: string; json: string | null }) {
+export function EnhancedNotes({
+  noteId,
+  json,
+  onChange,
+}: {
+  noteId: string;
+  json: string | null;
+  onChange?: (json: string) => void;
+}) {
   const doc = useMemo(() => parseDoc(json), [json]);
   const { data: segments = [] } = useQuery({
     queryKey: api.qk.segments(noteId),
@@ -48,7 +56,31 @@ export function EnhancedNotes({ noteId, json }: { noteId: string; json: string |
               <li key={bulletIndex} className="flex gap-2 text-[13px] leading-relaxed text-text">
                 <span className="mt-[0.45rem] size-1 shrink-0 rounded-full bg-subtle" />
                 <span>
-                  {bullet.text}
+                  <span
+                    contentEditable={Boolean(onChange)}
+                    suppressContentEditableWarning
+                    className={cn(onChange && "rounded-sm outline-none focus:bg-hover")}
+                    onBlur={(event) => {
+                      if (!onChange || !doc) return;
+                      const nextText = event.currentTarget.innerText.trim();
+                      if (nextText === bullet.text) return;
+                      const next: EnhancedDoc = {
+                        sections: doc.sections.map((section, sIdx) =>
+                          sIdx !== index
+                            ? section
+                            : {
+                                ...section,
+                                bullet_points: section.bullet_points.map((item, bIdx) =>
+                                  bIdx === bulletIndex ? { ...item, text: nextText } : item,
+                                ),
+                              },
+                        ),
+                      };
+                      onChange(JSON.stringify(next));
+                    }}
+                  >
+                    {bullet.text}
+                  </span>
                   {bullet.citations?.length > 0 && (
                     <span className="ml-1 inline-flex gap-0.5 align-baseline">
                       {bullet.citations.map((citation) => (

--- a/desktop/src/components/notes/NoteEditor.tsx
+++ b/desktop/src/components/notes/NoteEditor.tsx
@@ -1,17 +1,33 @@
-import { useEffect, useRef } from "react";
-import { EditorContent, useEditor } from "@tiptap/react";
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { EditorContent, useEditor, type Editor } from "@tiptap/react";
+import { BubbleMenu } from "@tiptap/react/menus";
 import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import TaskList from "@tiptap/extension-task-list";
 import TaskItem from "@tiptap/extension-task-item";
+import { Bold, Heading1, Heading2, Italic, List, ListOrdered, Minus, Quote, SquareCheck, Strikethrough } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 const AUTOSAVE_MS = 600;
 
-/**
- * Notes were historically stored as plain text. Anything that doesn't look
- * like markup is escaped and split into paragraphs so old notes still open.
- */
-function toEditorContent(raw: string): string {
+export type NoteDraft = {
+  text: string;
+  json: string;
+};
+
+export type NoteEditorHandle = {
+  replaceSelection: (text: string) => void;
+};
+
+function toEditorContent(json: string | null | undefined, raw: string): string | Record<string, unknown> {
+  if (json) {
+    try {
+      const parsed = JSON.parse(json) as Record<string, unknown>;
+      if (parsed && parsed.type === "doc") return parsed;
+    } catch {
+      /* fall through to plaintext / html */
+    }
+  }
   if (!raw) return "";
   if (raw.trimStart().startsWith("<")) return raw;
   return raw
@@ -27,21 +43,41 @@ function toEditorContent(raw: string): string {
     .join("");
 }
 
-export function NoteEditor({
-  noteId,
-  initialContent,
-  onSave,
-  onSelectionChange,
-}: {
-  noteId: string;
-  initialContent: string;
-  onSave: (html: string) => void;
-  onSelectionChange?: (text: string) => void;
-}) {
+const SLASH_ITEMS = [
+  { id: "h1", label: "Heading 1", icon: Heading1, run: (e: Editor) => e.chain().focus().toggleHeading({ level: 1 }).run() },
+  { id: "h2", label: "Heading 2", icon: Heading2, run: (e: Editor) => e.chain().focus().toggleHeading({ level: 2 }).run() },
+  { id: "bullet", label: "Bullet list", icon: List, run: (e: Editor) => e.chain().focus().toggleBulletList().run() },
+  { id: "number", label: "Numbered list", icon: ListOrdered, run: (e: Editor) => e.chain().focus().toggleOrderedList().run() },
+  { id: "todo", label: "To-do", icon: SquareCheck, run: (e: Editor) => e.chain().focus().toggleTaskList().run() },
+  { id: "quote", label: "Quote", icon: Quote, run: (e: Editor) => e.chain().focus().toggleBlockquote().run() },
+  { id: "hr", label: "Divider", icon: Minus, run: (e: Editor) => e.chain().focus().setHorizontalRule().run() },
+] as const;
+
+export const NoteEditor = forwardRef<
+  NoteEditorHandle,
+  {
+    noteId: string;
+    initialContent: string;
+    initialJson?: string | null;
+    onSave: (draft: NoteDraft) => void;
+    onSelectionChange?: (text: string) => void;
+  }
+>(function NoteEditor({ noteId, initialContent, initialJson, onSave, onSelectionChange }, ref) {
   const saveTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const latestHtml = useRef(initialContent);
+  const latest = useRef<NoteDraft>({ text: initialContent, json: initialJson ?? "" });
   const onSaveRef = useRef(onSave);
   onSaveRef.current = onSave;
+  const [slash, setSlash] = useState<{ query: string; from: number } | null>(null);
+  const [slashIndex, setSlashIndex] = useState(0);
+
+  const persist = (instance: Editor) => {
+    latest.current = {
+      text: instance.getText(),
+      json: JSON.stringify(instance.getJSON()),
+    };
+    clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(() => onSaveRef.current(latest.current), AUTOSAVE_MS);
+  };
 
   const editor = useEditor(
     {
@@ -49,14 +85,48 @@ export function NoteEditor({
         StarterKit.configure({ heading: { levels: [1, 2, 3] } }),
         TaskList,
         TaskItem.configure({ nested: true }),
-        Placeholder.configure({ placeholder: "Write notes" }),
+        Placeholder.configure({ placeholder: "Write notes, or type / for commands" }),
       ],
-      content: toEditorContent(initialContent),
-      editorProps: { attributes: { class: "tiptap" } },
+      content: toEditorContent(initialJson, initialContent),
+      editorProps: {
+        attributes: { class: "tiptap" },
+        handleKeyDown: (_view, event) => {
+          if (!slash) return false;
+          const matches = SLASH_ITEMS.filter((item) =>
+            item.label.toLowerCase().includes(slash.query.toLowerCase()),
+          );
+          if (event.key === "ArrowDown") {
+            event.preventDefault();
+            setSlashIndex((i) => (i + 1) % Math.max(matches.length, 1));
+            return true;
+          }
+          if (event.key === "ArrowUp") {
+            event.preventDefault();
+            setSlashIndex((i) => (i - 1 + Math.max(matches.length, 1)) % Math.max(matches.length, 1));
+            return true;
+          }
+          if (event.key === "Enter" && matches[slashIndex]) {
+            event.preventDefault();
+            return true;
+          }
+          if (event.key === "Escape") {
+            setSlash(null);
+            return true;
+          }
+          return false;
+        },
+      },
       onUpdate: ({ editor: instance }) => {
-        latestHtml.current = instance.getHTML();
-        clearTimeout(saveTimer.current);
-        saveTimer.current = setTimeout(() => onSaveRef.current(latestHtml.current), AUTOSAVE_MS);
+        persist(instance);
+        const { from } = instance.state.selection;
+        const textBefore = instance.state.doc.textBetween(Math.max(0, from - 32), from, "\n");
+        const match = textBefore.match(/(?:^|\n)\/([^\n/]*)$/);
+        if (match) {
+          setSlash({ query: match[1] ?? "", from: from - match[0].replace(/^\n/, "").length });
+          setSlashIndex(0);
+        } else {
+          setSlash(null);
+        }
       },
       onSelectionUpdate: ({ editor: instance }) => {
         if (!onSelectionChange) return;
@@ -67,14 +137,116 @@ export function NoteEditor({
     [noteId],
   );
 
-  // Never let a pending debounce drop the last keystroke on unmount or navigation.
+  useImperativeHandle(ref, () => ({
+    replaceSelection: (text: string) => {
+      if (!editor) return;
+      editor.chain().focus().insertContent(text.replace(/\n/g, "<br>")).run();
+      persist(editor);
+    },
+  }));
+
   useEffect(
     () => () => {
       clearTimeout(saveTimer.current);
-      if (latestHtml.current !== initialContent) onSaveRef.current(latestHtml.current);
+      if (latest.current.json || latest.current.text !== initialContent) {
+        onSaveRef.current(latest.current);
+      }
     },
     [initialContent, noteId],
   );
 
-  return <EditorContent editor={editor} className="min-h-[40vh]" />;
+  const slashMatches = SLASH_ITEMS.filter((item) =>
+    item.label.toLowerCase().includes((slash?.query ?? "").toLowerCase()),
+  );
+
+  const applySlash = (item: (typeof SLASH_ITEMS)[number]) => {
+    if (!editor || !slash) return;
+    const to = editor.state.selection.from;
+    editor.chain().focus().deleteRange({ from: slash.from, to }).run();
+    item.run(editor);
+    setSlash(null);
+  };
+
+  useEffect(() => {
+    if (!editor || !slash) return;
+    const onEnter = (event: KeyboardEvent) => {
+      if (event.key !== "Enter" || !slashMatches[slashIndex]) return;
+      event.preventDefault();
+      applySlash(slashMatches[slashIndex]);
+    };
+    document.addEventListener("keydown", onEnter, true);
+    return () => document.removeEventListener("keydown", onEnter, true);
+  });
+
+  return (
+    <div className="relative">
+      {editor && (
+        <BubbleMenu editor={editor} className="flex items-center gap-0.5 rounded-full border border-border bg-elevated px-1 py-0.5 shadow-lg">
+          <MarkButton label="Bold" active={editor.isActive("bold")} onClick={() => editor.chain().focus().toggleBold().run()}>
+            <Bold className="size-3.5" />
+          </MarkButton>
+          <MarkButton label="Italic" active={editor.isActive("italic")} onClick={() => editor.chain().focus().toggleItalic().run()}>
+            <Italic className="size-3.5" />
+          </MarkButton>
+          <MarkButton label="Strike" active={editor.isActive("strike")} onClick={() => editor.chain().focus().toggleStrike().run()}>
+            <Strikethrough className="size-3.5" />
+          </MarkButton>
+          <MarkButton label="Bullet list" active={editor.isActive("bulletList")} onClick={() => editor.chain().focus().toggleBulletList().run()}>
+            <List className="size-3.5" />
+          </MarkButton>
+        </BubbleMenu>
+      )}
+
+      <EditorContent editor={editor} className="min-h-[40vh]" />
+
+      {slash && slashMatches.length > 0 && (
+        <div className="absolute left-0 top-8 z-20 w-56 overflow-hidden rounded-xl border border-border bg-elevated p-1 shadow-lg">
+          <p className="px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-subtle">Insert</p>
+          {slashMatches.map((item, index) => (
+            <button
+              key={item.id}
+              type="button"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                applySlash(item);
+              }}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[13px]",
+                index === slashIndex ? "bg-hover text-text" : "text-muted hover:bg-hover hover:text-text",
+              )}
+            >
+              <item.icon className="size-3.5" />
+              {item.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+});
+
+function MarkButton({
+  label,
+  active,
+  onClick,
+  children,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onClick}
+      className={cn(
+        "grid size-7 place-items-center rounded-full transition-colors",
+        active ? "bg-selected text-text" : "text-muted hover:bg-hover hover:text-text",
+      )}
+    >
+      {children}
+    </button>
+  );
 }

--- a/desktop/src/components/pages/NotePage.tsx
+++ b/desktop/src/components/pages/NotePage.tsx
@@ -15,7 +15,7 @@ import * as api from "@/lib/api";
 import { formatDayLabel } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { useAppStore } from "@/store/app";
-import { NoteEditor } from "@/components/notes/NoteEditor";
+import { NoteEditor, type NoteEditorHandle } from "@/components/notes/NoteEditor";
 import { EnhancedNotes } from "@/components/notes/EnhancedNotes";
 import { TranscriptPanel } from "@/components/notes/TranscriptPanel";
 import { RecordingControls } from "@/components/notes/RecordingControls";
@@ -46,6 +46,7 @@ export function NotePage({ noteId }: { noteId: string }) {
 
   const [tab, setTab] = useState<Tab>("notes");
   const [selection, setSelection] = useState("");
+  const editorRef = useRef<NoteEditorHandle>(null);
 
   const { data: note, isLoading } = useQuery({
     queryKey: api.qk.meeting(noteId),
@@ -63,8 +64,14 @@ export function NotePage({ noteId }: { noteId: string }) {
   const { data: people = [] } = useQuery({ queryKey: api.qk.people(), queryFn: api.listPeople });
 
   const saveBody = useMutation({
-    mutationFn: (html: string) => api.saveScratchpad(noteId, html),
+    mutationFn: (draft: { text: string; json: string }) => api.saveScratchpad(noteId, draft.text, draft.json),
     onError: (e) => toast.error(e, "Your latest edits may not be saved."),
+  });
+
+  const saveEnhanced = useMutation({
+    mutationFn: (json: string) => api.saveEnhancedNotes(noteId, json),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: api.qk.meeting(noteId) }),
+    onError: (e) => toast.error(e, "Enhanced notes weren't saved."),
   });
 
   const saveTitle = useMutation({
@@ -154,7 +161,10 @@ export function NotePage({ noteId }: { noteId: string }) {
 
   const reprompt = useMutation({
     mutationFn: (instruction: string) => api.repromptSelection(noteId, selection, instruction),
-    onSuccess: (result) => toast.info("Rewrite suggestion", result.slice(0, 240)),
+    onSuccess: (result) => {
+      editorRef.current?.replaceSelection(result.trim());
+      toast.success("Selection rewritten");
+    },
     onError: (e) => toast.error(e),
   });
 
@@ -347,12 +357,18 @@ export function NotePage({ noteId }: { noteId: string }) {
                 transition={snappy}
               >
                 {tab === "enhanced" && hasEnhanced ? (
-                  <EnhancedNotes noteId={noteId} json={note.enhanced_notes_json} />
+                  <EnhancedNotes
+                    noteId={noteId}
+                    json={note.enhanced_notes_json}
+                    onChange={(next) => saveEnhanced.mutate(next)}
+                  />
                 ) : (
                   <NoteEditor
+                    ref={editorRef}
                     noteId={noteId}
                     initialContent={note.scratchpad_raw}
-                    onSave={(html) => saveBody.mutate(html)}
+                    initialJson={note.scratchpad_json}
+                    onSave={(draft) => saveBody.mutate(draft)}
                     onSelectionChange={setSelection}
                   />
                 )}

--- a/desktop/src/lib/api.ts
+++ b/desktop/src/lib/api.ts
@@ -28,8 +28,10 @@ export const listMeetings = (folderId?: string | null) =>
 export const getMeeting = (id: string) => invoke<Meeting>("get_meeting", { id });
 export const createMeeting = (title: string, folderId?: string | null) =>
   invoke<Meeting>("create_meeting", { title, folderId: folderId ?? null });
-export const saveScratchpad = (id: string, scratchpadRaw: string) =>
-  invoke<void>("save_scratchpad", { id, scratchpadRaw });
+export const saveScratchpad = (id: string, scratchpadRaw: string, scratchpadJson?: string | null) =>
+  invoke<void>("save_scratchpad", { id, scratchpadRaw, scratchpadJson: scratchpadJson ?? null });
+export const saveEnhancedNotes = (id: string, enhancedNotesJson: string) =>
+  invoke<void>("save_enhanced_notes", { id, enhancedNotesJson });
 export const saveTitle = (id: string, title: string) => invoke<void>("save_title", { id, title });
 export const deleteMeeting = (id: string) => invoke<void>("delete_meeting", { id });
 export const moveMeeting = (id: string, folderId?: string | null) =>

--- a/desktop/src/lib/directory.test.ts
+++ b/desktop/src/lib/directory.test.ts
@@ -23,6 +23,7 @@ const meetings: Meeting[] = [
     duration_ms: null,
     calendar_event_id: null,
     scratchpad_raw: "",
+    scratchpad_json: null,
     enhanced_notes_json: null,
     transcript_json: null,
     updated_at: "2026-08-15 10:00:00",

--- a/desktop/src/lib/types.ts
+++ b/desktop/src/lib/types.ts
@@ -26,6 +26,7 @@ export type Meeting = {
   duration_ms: number | null;
   calendar_event_id: string | null;
   scratchpad_raw: string;
+  scratchpad_json: string | null;
   enhanced_notes_json: string | null;
   transcript_json: string | null;
   updated_at: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Notes were stored as a HTML/plaintext blob, enhance citations were not checked, and rewrite only toasted a suggestion.

### Editor
- Autosave writes ProseMirror JSON (`scratchpad_json`, migration v7) plus plaintext for FTS/enhance
- `/` slash menu: heading, lists, to-do, quote, divider
- Bubble menu: bold, italic, strike, bullets
- Selection rewrite (Tighten / Make it a list / Expand) replaces the selected text in the editor

### Enhanced notes
- Bullets are editable and saved via `save_enhanced_notes`
- Citation ids that are not in the transcript are stripped on enhance and on save

Stacks on #23.

`cargo check`, `tsc --noEmit`, and `vitest` directory tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ee175ca-82e7-4ea8-84df-a8dec90d0a6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

